### PR TITLE
Make it work with applicationinsights 0.22

### DIFF
--- a/lib/controllers/messages.ts
+++ b/lib/controllers/messages.ts
@@ -212,11 +212,14 @@ export function CreateMessageHandler(
     if (messagePayload.dry_run) {
       // if the user requested a dry run, we respond with the attributes
       // that we received
-      applicationInsightsClient.trackEvent({name: eventName, properties: {
+      applicationInsightsClient.trackEvent({
+        name: eventName,
+        properties: {
           ...eventData,
           dryRun: "true",
           success: "true",
-      }});
+        },
+      });
       const response: IResponseDryRun = {
         bodyShort: messagePayload.body_short,
         senderOrganizationId: userOrganization.organizationId,
@@ -246,11 +249,14 @@ export function CreateMessageHandler(
       const retrievedMessage = errorOrMessage.right;
       context.log(`>> message created|${fiscalCode}|${userOrganization.organizationId}|${retrievedMessage.id}`);
 
-      applicationInsightsClient.trackEvent({name: eventName, properties: {
-        ...eventData,
-        dryRun: "false",
-        success: "true",
-      }});
+      applicationInsightsClient.trackEvent({
+        name: eventName,
+        properties: {
+          ...eventData,
+          dryRun: "false",
+          success: "true",
+        },
+      });
 
       // prepare the created message event
       const createdMessageEvent: ICreatedMessageEvent = {

--- a/lib/controllers/messages.ts
+++ b/lib/controllers/messages.ts
@@ -61,7 +61,7 @@ import {
   MessageModel,
 } from "../models/message";
 
-const ApplicationInsightsClient = ApplicationInsights.getClient();
+const ApplicationInsightsClient = ApplicationInsights.defaultClient;
 
 /**
  * Input and output bindings for this function
@@ -212,11 +212,11 @@ export function CreateMessageHandler(
     if (messagePayload.dry_run) {
       // if the user requested a dry run, we respond with the attributes
       // that we received
-      applicationInsightsClient.trackEvent(eventName, {
+      applicationInsightsClient.trackEvent({name: eventName, properties: {
           ...eventData,
           dryRun: "true",
           success: "true",
-      });
+      }});
       const response: IResponseDryRun = {
         bodyShort: messagePayload.body_short,
         senderOrganizationId: userOrganization.organizationId,
@@ -246,11 +246,11 @@ export function CreateMessageHandler(
       const retrievedMessage = errorOrMessage.right;
       context.log(`>> message created|${fiscalCode}|${userOrganization.organizationId}|${retrievedMessage.id}`);
 
-      applicationInsightsClient.trackEvent(eventName, {
+      applicationInsightsClient.trackEvent({name: eventName, properties: {
         ...eventData,
         dryRun: "false",
         success: "true",
-      });
+      }});
 
       // prepare the created message event
       const createdMessageEvent: ICreatedMessageEvent = {

--- a/lib/controllers/messages.ts
+++ b/lib/controllers/messages.ts
@@ -5,8 +5,7 @@
 import * as express from "express";
 import * as ulid from "ulid";
 
-// cannot use "import * from", see https://goo.gl/HbzFra
-import ApplicationInsightsClient = require("../../node_modules/applicationinsights/out/Library/Client");
+import * as ApplicationInsights from "applicationinsights";
 
 import { IContext } from "azure-function-express-cloudify";
 
@@ -61,6 +60,8 @@ import {
   IPublicExtendedMessage,
   MessageModel,
 } from "../models/message";
+
+const ApplicationInsightsClient = ApplicationInsights.getClient();
 
 /**
  * Input and output bindings for this function
@@ -193,7 +194,7 @@ type IGetMessagesHandler = (
  * Returns a type safe CreateMessage handler.
  */
 export function CreateMessageHandler(
-  applicationInsightsClient: ApplicationInsightsClient,
+  applicationInsightsClient: typeof ApplicationInsightsClient,
   messageModel: MessageModel,
 ): ICreateMessageHandler {
   return async (context, _, userAttributes, fiscalCode, messagePayload) => {
@@ -275,7 +276,7 @@ export function CreateMessageHandler(
  * Wraps a CreateMessage handler inside an Express request handler.
  */
 export function CreateMessage(
-  applicationInsightsClient: ApplicationInsightsClient,
+  applicationInsightsClient: typeof ApplicationInsightsClient,
   organizationModel: OrganizationModel,
   messageModel: MessageModel,
 ): express.RequestHandler {

--- a/lib/controllers/messages.ts
+++ b/lib/controllers/messages.ts
@@ -212,13 +212,10 @@ export function CreateMessageHandler(
     if (messagePayload.dry_run) {
       // if the user requested a dry run, we respond with the attributes
       // that we received
-      applicationInsightsClient.trackEvent({
-        name: eventName,
-        properties: {
+      applicationInsightsClient.trackEvent(eventName, {
           ...eventData,
           dryRun: "true",
           success: "true",
-        },
       });
       const response: IResponseDryRun = {
         bodyShort: messagePayload.body_short,
@@ -249,13 +246,10 @@ export function CreateMessageHandler(
       const retrievedMessage = errorOrMessage.right;
       context.log(`>> message created|${fiscalCode}|${userOrganization.organizationId}|${retrievedMessage.id}`);
 
-      applicationInsightsClient.trackEvent({
-        name: eventName,
-        properties: {
-          ...eventData,
-          dryRun: "false",
-          success: "true",
-        },
+      applicationInsightsClient.trackEvent(eventName, {
+        ...eventData,
+        dryRun: "false",
+        success: "true",
       });
 
       // prepare the created message event

--- a/lib/emailnotifications_queue_handler.ts
+++ b/lib/emailnotifications_queue_handler.ts
@@ -27,7 +27,7 @@ import { INotificationEvent, isNotificationEvent } from "./models/notification_e
 import { MessageModel } from "./models/message";
 import { INotification, NotificationChannelStatus, NotificationModel } from "./models/notification";
 
-const ApplicationInsightsClient = ApplicationInsights.getClient();
+const ApplicationInsightsClient = ApplicationInsights.defaultClient;
 
 // Setup DocumentDB
 
@@ -213,10 +213,10 @@ async function handleNotification(
 
   if (sendResult.isLeft) {
     // we got an error while sending the email
-    appInsightsClient.trackEvent(eventName, {
+    appInsightsClient.trackEvent({name: eventName, properties: {
       ...eventContent,
       success: "false",
-    });
+    }});
     const error = sendResult.left;
     winston.warn(
       `Error while sending email|notification=${notificationId}|message=${messageId}|error=${error.message}`,
@@ -224,10 +224,10 @@ async function handleNotification(
     return left(ProcessingError.TRANSIENT);
   }
 
-  appInsightsClient.trackEvent(eventName, {
+  appInsightsClient.trackEvent({name: eventName, properties: {
     ...eventContent,
     success: "true",
-  });
+  }});
 
   // now we can update the notification status
   // TODO: store the message ID for handling bounces and delivery updates
@@ -264,7 +264,7 @@ export function index(context: IContextWithBindings): void {
   winston.debug(`STARTED|${context.invocationId}`);
 
   // Setup ApplicationInsights
-  const appInsightsClient = ApplicationInsights.getClient();
+  const appInsightsClient = ApplicationInsights.defaultClient;
 
   const emailNotificationEvent = context.bindings.notificationEvent;
 

--- a/lib/emailnotifications_queue_handler.ts
+++ b/lib/emailnotifications_queue_handler.ts
@@ -213,10 +213,13 @@ async function handleNotification(
 
   if (sendResult.isLeft) {
     // we got an error while sending the email
-    appInsightsClient.trackEvent({name: eventName, properties: {
-      ...eventContent,
-      success: "false",
-    }});
+    appInsightsClient.trackEvent({
+      name: eventName,
+      properties: {
+        ...eventContent,
+        success: "false",
+      },
+    });
     const error = sendResult.left;
     winston.warn(
       `Error while sending email|notification=${notificationId}|message=${messageId}|error=${error.message}`,
@@ -224,10 +227,13 @@ async function handleNotification(
     return left(ProcessingError.TRANSIENT);
   }
 
-  appInsightsClient.trackEvent({name: eventName, properties: {
-    ...eventContent,
-    success: "true",
-  }});
+  appInsightsClient.trackEvent({
+    name: eventName,
+    properties: {
+      ...eventContent,
+      success: "true",
+    },
+  });
 
   // now we can update the notification status
   // TODO: store the message ID for handling bounces and delivery updates

--- a/lib/emailnotifications_queue_handler.ts
+++ b/lib/emailnotifications_queue_handler.ts
@@ -7,9 +7,7 @@
 
 import * as winston from "winston";
 
-// cannot use "import * from", see https://goo.gl/HbzFra
-import ApplicationInsights = require("applicationinsights");
-import ApplicationInsightsClient = require("../node_modules/applicationinsights/out/Library/Client");
+import * as ApplicationInsights from "applicationinsights";
 
 import { configureAzureContextTransport } from "./utils/logging";
 
@@ -28,6 +26,8 @@ import { INotificationEvent, isNotificationEvent } from "./models/notification_e
 
 import { MessageModel } from "./models/message";
 import { INotification, NotificationChannelStatus, NotificationModel } from "./models/notification";
+
+const ApplicationInsightsClient = ApplicationInsights.getClient();
 
 // Setup DocumentDB
 
@@ -124,7 +124,7 @@ function setEmailNotificationSend(notification: INotification): INotification {
  * It will then send the email.
  */
 async function handleNotification(
-  appInsightsClient: ApplicationInsightsClient,
+  appInsightsClient: typeof ApplicationInsightsClient,
   notificationModel: NotificationModel,
   messageModel: MessageModel,
   messageId: string,

--- a/lib/emailnotifications_queue_handler.ts
+++ b/lib/emailnotifications_queue_handler.ts
@@ -213,12 +213,9 @@ async function handleNotification(
 
   if (sendResult.isLeft) {
     // we got an error while sending the email
-    appInsightsClient.trackEvent({
-      name: eventName,
-      properties: {
-        ...eventContent,
-        success: "false",
-      },
+    appInsightsClient.trackEvent(eventName, {
+      ...eventContent,
+      success: "false",
     });
     const error = sendResult.left;
     winston.warn(
@@ -227,12 +224,9 @@ async function handleNotification(
     return left(ProcessingError.TRANSIENT);
   }
 
-  appInsightsClient.trackEvent({
-    name: eventName,
-    properties: {
-      ...eventContent,
-      success: "true",
-    },
+  appInsightsClient.trackEvent(eventName, {
+    ...eventContent,
+    success: "true",
   });
 
   // now we can update the notification status
@@ -270,7 +264,7 @@ export function index(context: IContextWithBindings): void {
   winston.debug(`STARTED|${context.invocationId}`);
 
   // Setup ApplicationInsights
-  const appInsightsClient = new ApplicationInsights.TelemetryClient();
+  const appInsightsClient = ApplicationInsights.getClient();
 
   const emailNotificationEvent = context.bindings.notificationEvent;
 

--- a/lib/public_api_v1.ts
+++ b/lib/public_api_v1.ts
@@ -58,7 +58,7 @@ const notificationModel = new NotificationModel(documentClient, notificationsCol
 
 // Setup ApplicationInsights
 
-const appInsightsClient = ApplicationInsights.getClient();
+const appInsightsClient = ApplicationInsights.defaultClient;
 
 // Setup handlers
 

--- a/lib/public_api_v1.ts
+++ b/lib/public_api_v1.ts
@@ -7,8 +7,7 @@ import { IContext } from "azure-function-express-cloudify";
 import * as express from "express";
 import * as winston from "winston";
 
-// cannot use "import * from", see https://goo.gl/HbzFra
-import ApplicationInsights = require("applicationinsights");
+import * as ApplicationInsights from "applicationinsights";
 
 import { configureAzureContextTransport } from "./utils/logging";
 

--- a/lib/public_api_v1.ts
+++ b/lib/public_api_v1.ts
@@ -58,7 +58,7 @@ const notificationModel = new NotificationModel(documentClient, notificationsCol
 
 // Setup ApplicationInsights
 
-const appInsightsClient = new ApplicationInsights.TelemetryClient();
+const appInsightsClient = ApplicationInsights.getClient();
 
 // Setup handlers
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@types/applicationinsights": "^0.15.34",
     "@types/documentdb": "^1.10.2",
     "@types/express": "^4.0.36",
     "@types/js-yaml": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
+    "@types/applicationinsights": "^0.15.34",
     "@types/documentdb": "^1.10.2",
     "@types/express": "^4.0.36",
     "@types/js-yaml": "^3.9.1",


### PR DESCRIPTION
It looks like TelemetryClient works only for numeric (integer) properties (see https://github.com/Microsoft/ApplicationInsights-node.js/blob/develop/Library/TelemetryTypes/EventTelemetry.ts)

Probably it's safer to switch back to "defaultClient" (without creating new client instances with 'new')
