### PR TITLE
[#151262556] Save message content in inbox only if enabled in profile

### DIFF
--- a/lib/controllers/messages.ts
+++ b/lib/controllers/messages.ts
@@ -67,8 +67,10 @@ import { OrganizationModel } from "../models/organization";
 
 import {
   IMessage,
-  INewMessage,
+  IMessageContent,
+  INewMessageWithoutContent,
   IRetrievedMessage,
+  IRetrievedMessageWithoutContent,
   MessageModel
 } from "../models/message";
 
@@ -246,11 +248,10 @@ export function CreateMessageHandler(
 
     // we need the user to be associated to a valid organization for him
     // to be able to send a message
-    const message: INewMessage = {
-      bodyShort: messagePayload.content.body_short,
+    const message: INewMessageWithoutContent = {
       fiscalCode,
       id: toNonEmptyString(ulid()).get,
-      kind: "INewMessage",
+      kind: "INewMessageWithoutContent",
       senderOrganizationId: userOrganization.organizationId,
       senderUserId: auth.userId
     };
@@ -287,10 +288,21 @@ export function CreateMessageHandler(
         }
       });
 
+      const messageContent: IMessageContent = {
+        bodyShort: messagePayload.content.body_short
+      };
+
+      const retrievedMessageWithoutContent: IRetrievedMessageWithoutContent = {
+        ...retrievedMessage,
+        content: undefined,
+        kind: "IRetrievedMessageWithoutContent"
+      };
+
       // prepare the created message event
       const createdMessageEvent: ICreatedMessageEvent = {
         defaultAddresses: messagePayload.default_addresses,
-        message: retrievedMessage
+        message: retrievedMessageWithoutContent,
+        messageContent
       };
 
       // queue the message to the created messages queue by setting

--- a/lib/models/__tests__/created_message_event.test.ts
+++ b/lib/models/__tests__/created_message_event.test.ts
@@ -13,12 +13,14 @@ describe("", () => {
           _self:
             "dbs/LgNRAA==/colls/LgNRANj9nwA=/docs/LgNRANj9nwBgAAAAAAAAAA==/",
           _ts: 1505754168,
-          bodyShort: "Hello, world! This works! 15",
           fiscalCode: "FRLFRC73E04B157I",
           id: "01BTAZ2HS1PWDJERA510FDXYV4",
           kind: "IRetrievedMessage",
           senderOrganizationId: "agid",
           senderUserId: "u123"
+        },
+        messageContent: {
+          bodyShort: "Hello, world! This works! 15"
         }
       }
     ];

--- a/lib/models/created_message_event.ts
+++ b/lib/models/created_message_event.ts
@@ -5,7 +5,12 @@ import {
   NewMessageDefaultAddresses
 } from "../api/definitions/NewMessageDefaultAddresses";
 
-import { IRetrievedMessage, isIRetrievedMessage } from "./message";
+import {
+  IMessageContent,
+  IRetrievedMessageWithoutContent,
+  isIMessageContent,
+  isIRetrievedMessageWithoutContent
+} from "./message";
 
 /**
  * Payload of a created message event.
@@ -14,7 +19,8 @@ import { IRetrievedMessage, isIRetrievedMessage } from "./message";
  * Messages API.
  */
 export interface ICreatedMessageEvent {
-  readonly message: IRetrievedMessage;
+  readonly messageContent: IMessageContent;
+  readonly message: IRetrievedMessageWithoutContent;
   readonly defaultAddresses?: NewMessageDefaultAddresses;
 }
 
@@ -23,7 +29,8 @@ export interface ICreatedMessageEvent {
  */
 export const isICreatedMessageEvent = is<ICreatedMessageEvent>(
   arg =>
-    isIRetrievedMessage(arg.message) &&
+    isIRetrievedMessageWithoutContent(arg.message) &&
+    isIMessageContent(arg.messageContent) &&
     (!arg.defaultAddresses ||
       isNewMessageDefaultAddresses(arg.defaultAddresses))
 );

--- a/lib/models/notification_event.ts
+++ b/lib/models/notification_event.ts
@@ -1,6 +1,7 @@
 import is from "ts-is";
 
 import { isNonEmptyString, NonEmptyString } from "../utils/strings";
+import { IMessageContent, isIMessageContent } from "./message";
 
 /**
  * Payload of a notification event.
@@ -10,6 +11,7 @@ import { isNonEmptyString, NonEmptyString } from "../utils/strings";
  */
 export interface INotificationEvent {
   readonly messageId: NonEmptyString;
+  readonly messageContent: IMessageContent;
   readonly notificationId: NonEmptyString;
 }
 
@@ -20,5 +22,6 @@ export const isNotificationEvent = is<INotificationEvent>(
   arg =>
     arg &&
     isNonEmptyString(arg.notificationId) &&
-    isNonEmptyString(arg.messageId)
+    isNonEmptyString(arg.messageId) &&
+    isIMessageContent(arg.messageContent)
 );

--- a/lib/models/profile.ts
+++ b/lib/models/profile.ts
@@ -19,8 +19,16 @@ import { NonEmptyString } from "../utils/strings";
  * Base interface for Profile objects
  */
 export interface IProfile {
+  // the fiscal code of the citized associated to this profile
   readonly fiscalCode: FiscalCode;
+
+  // the preferred email for receiving email notifications
+  // if defined, will override the default email provided by the API client
+  // if defined, will enable email notifications for the citizen
   readonly email?: EmailAddress;
+
+  // whether to store the content of messages sent to this citizen
+  readonly isStorageOfMessageContentEnabled?: boolean;
 }
 
 /**

--- a/lib/utils/documentdb_model_versioned.ts
+++ b/lib/utils/documentdb_model_versioned.ts
@@ -51,9 +51,9 @@ export function generateVersionedModelId(
 
 export abstract class DocumentDbModelVersioned<
   T,
-  TN extends T & IVersionedModel & DocumentDb.NewDocument,
-  TR extends DocumentDb.RetrievedDocument & IVersionedModel
-> extends DocumentDbModel<TN, TR> {
+  TN extends T & DocumentDb.NewDocument & IVersionedModel,
+  TR extends T & DocumentDb.RetrievedDocument & IVersionedModel
+> extends DocumentDbModel<T, TN, TR> {
   protected getModelId: (o: T) => ModelId;
 
   protected versionateModel: (
@@ -61,8 +61,6 @@ export abstract class DocumentDbModelVersioned<
     id: string,
     version: NonNegativeNumber
   ) => TN;
-
-  protected toBaseType: (o: TR) => T;
 
   public async create(
     document: T,


### PR DESCRIPTION
This commit also decouples the storage of message content in the message
record from the CreateMessage API handler, moving it to the async create
message handles.