### PR TITLE
fix: error in route definition

### DIFF
--- a/Openapi/function.json
+++ b/Openapi/function.json
@@ -8,7 +8,7 @@
       "direction" : "in",
       "name"      : "req",
       "methods"   : [ "get" ],
-      "route"     : "/api/v1/swagger.json"
+      "route"     : "api/v1/swagger.json"
     }, {
       "type"      : "http",
       "direction" : "out",


### PR DESCRIPTION
 The route template separator character '/' cannot appear consecutively. It must be separated by either a parameter or a literal value.
 Parameter name: routeTemplate. della funzione ($Openapi)