### PR TITLE
fix: align api to specs

### DIFF
--- a/api/public_api_v1.yaml
+++ b/api/public_api_v1.yaml
@@ -130,7 +130,8 @@ paths:
                 Location (URL) of created message resource.
                 A GET request to this URL returns the message status and details.
           examples:
-            application/json: {}
+            application/json:
+              id: 01BX9NSMKVXXS5PSP2FATZMYYY
         '400':
           description: Invalid payload.
           schema:

--- a/lib/api/public_api_v1.ts
+++ b/lib/api/public_api_v1.ts
@@ -148,7 +148,9 @@ export const specs = {
                   "Location (URL) of created message resource.\nA GET request to this URL returns the message status and details."
               }
             },
-            examples: { "application/json": {} }
+            examples: {
+              "application/json": { id: "01BX9NSMKVXXS5PSP2FATZMYYY" }
+            }
           },
           "400": {
             description: "Invalid payload.",

--- a/lib/controllers/messages.ts
+++ b/lib/controllers/messages.ts
@@ -328,7 +328,7 @@ export function CreateMessageHandler(
     return ResponseSuccessRedirectToResource(
       newMessageWithoutContent,
       `/api/v1/messages/${fiscalCode}/${newMessageWithoutContent.id}`,
-      {}
+      { id: newMessageWithoutContent.id }
     );
   };
 }

--- a/lib/utils/response.ts
+++ b/lib/utils/response.ts
@@ -100,7 +100,7 @@ export function ResponseSuccessRedirectToResource<T, V>(
     apply: res =>
       res
         .set("Location", url)
-        .status(202)
+        .status(201)
         .json(payload),
     kind: "IResponseSuccessRedirectToResource",
     payload,


### PR DESCRIPTION
when submitMessage success:

- specs say 201 (not 202) when 
- refactor: returns message id instead of empty object 