### PR TITLE
fix: removed default_address from submit message example

### DIFF
--- a/api/public_api_v1.yaml
+++ b/api/public_api_v1.yaml
@@ -118,8 +118,6 @@ paths:
                 Vestibulum in eros sapien. Donec ac odio sit amet dui semper ornare eget nec odio. Pellentesque habitant
                 morbi tristique senectus et netus et malesuada fames ac turpis egestas. Praesent nibh ex, mattis sit amet
                 felis id, sodales euismod velit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-            default_addresses:
-              email: foobar@example.com
       responses:
         '201':
           description: Message created.

--- a/lib/api/public_api_v1.ts
+++ b/lib/api/public_api_v1.ts
@@ -132,8 +132,7 @@ export const specs = {
                   subject: "ipsum labore deserunt fugiat",
                   markdown:
                     "Nullam dapibus metus sed elementum efficitur. Curabitur facilisis sagittis risus nec sodales. Vestibulum in eros sapien. Donec ac odio sit amet dui semper ornare eget nec odio. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Praesent nibh ex, mattis sit amet felis id, sodales euismod velit. Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-                },
-                default_addresses: { email: "foobar@example.com" }
+                }
               }
             }
           }


### PR DESCRIPTION
Quando un developer si iscrive alle API, non è ancora autorizzato ad usare la funzione `default_address`, per cui togliamolo dall'esempio di base dell'API.