### PR TITLE
chore: use yarn instead of npm

### DIFF
--- a/deploy.cmd
+++ b/deploy.cmd
@@ -103,8 +103,9 @@ echo Restoring npm packages in %1
 
 IF EXIST "%1\package.json" (
   pushd "%1"
-  call npm install
-  call npm run build
+  call npm install -g yarn
+  call yarn install
+  call yarn build
   IF !ERRORLEVEL! NEQ 0 goto error
   popd
 )


### PR DESCRIPTION
using npm results in failed deployment:

`Module '"D:/home/site/wwwroot/node_modules/ulid/index"' resolves to a non-module entity and cannot be imported using this construct.`

with yarn everything works. 

accidentally, it's fixed in production atm as I once ran yarn install from kudu console.
