### PR TITLE
refactor: make service optional

### DIFF
--- a/lib/controllers/__tests__/messages.test.ts
+++ b/lib/controllers/__tests__/messages.test.ts
@@ -65,14 +65,14 @@ const aMessageBodyMarkdown = _getO(toMessageBodyMarkdown("test".repeat(80)));
 const someUserAttributes: IAzureUserAttributes = {
   email: anEmail,
   kind: "IAzureUserAttributes",
-  service: {
+  service: some({
     authorizedCIDRs: toAuthorizedCIDRs([]),
     authorizedRecipients: new Set([]),
     departmentName: _getO(toNonEmptyString("IT")),
     organizationName: _getO(toNonEmptyString("AgID")),
     serviceId: _getO(toNonEmptyString("test")),
     serviceName: _getO(toNonEmptyString("Test"))
-  }
+  })
 };
 
 const aUserAuthenticationDeveloper: IAzureApiAuthorization = {
@@ -252,10 +252,10 @@ describe("CreateMessageHandler", () => {
       log: jest.fn()
     };
 
-    const anAuthorizedService = {
-      ...someUserAttributes.service,
+    const anAuthorizedService = someUserAttributes.service.map(service => ({
+      ...service,
       authorizedRecipients: new Set([aFiscalCode])
-    };
+    }));
 
     const someAuthorizedUserAttributes = {
       ...someUserAttributes,

--- a/lib/utils/middlewares/__tests__/azure_user_attributes.test.ts
+++ b/lib/utils/middlewares/__tests__/azure_user_attributes.test.ts
@@ -102,7 +102,7 @@ describe("AzureUserAttributesMiddleware", () => {
     }
   });
 
-  it("should fail if the user service does not exist", async () => {
+  it("should proceed if the user service does not exist", async () => {
     const serviceModel = {
       findOneByServiceId: jest.fn(() => Promise.resolve(right(none)))
     };
@@ -125,9 +125,9 @@ describe("AzureUserAttributesMiddleware", () => {
     expect(serviceModel.findOneByServiceId).toHaveBeenCalledWith(
       headers["x-subscription-id"]
     );
-    expect(isLeft(result)).toBeTruthy();
-    if (isLeft(result)) {
-      expect(result.value.kind).toEqual("IResponseErrorForbiddenNotAuthorized");
+    expect(isRight(result)).toBeTruthy();
+    if (isRight(result)) {
+      expect(result.value.kind).toEqual("IAzureUserAttributes");
     }
   });
 
@@ -156,10 +156,12 @@ describe("AzureUserAttributesMiddleware", () => {
     expect(isRight(result));
     if (isRight(result)) {
       const attributes = result.value;
-      expect(attributes.service).toEqual({
-        ...aService,
-        authorizedRecipients: new Set()
-      });
+      expect(attributes.service).toEqual(
+        some({
+          ...aService,
+          authorizedRecipients: new Set()
+        })
+      );
     }
   });
 

--- a/lib/utils/source_ip_check.ts
+++ b/lib/utils/source_ip_check.ts
@@ -162,5 +162,10 @@ export function clientIPAndCidrTuple(
   clientIp: ClientIp,
   userAttributes: IAzureUserAttributes
 ): Tuple2<ClientIp, ReadonlySet<string>> {
-  return Tuple2(clientIp, userAttributes.service.authorizedCIDRs);
+  // if no service is found for this user's subscription
+  // return an empty set (no IP restrictions)
+  if (isNone(userAttributes.service)) {
+    return Tuple2(clientIp, new Set());
+  }
+  return Tuple2(clientIp, userAttributes.service.value.authorizedCIDRs);
 }


### PR DESCRIPTION
This PR makes Service(s) optional. Why ? Because otherwise we have a chicken-egg problem: actually the APIs are callable only when there's a service tied to the user's subscription, so you cannot create a service,  using the API, if there's no service already setup for the caller account. This causes a "deadlock" in the 
https://github.com/teamdigitale/digital-citizenship-onboarding web application that needs to create an administrative account to manage API users programmatically.