### PR TITLE
chore: use ulid 2.x

### DIFF
--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -5,7 +5,7 @@
  * to each configured channel.
  */
 
-import * as ulid from "ulid";
+import { ulid } from "ulid";
 import * as winston from "winston";
 
 import { IContext } from "azure-functions-types";

--- a/lib/utils/strings.ts
+++ b/lib/utils/strings.ts
@@ -1,5 +1,5 @@
 import is from "ts-is";
-import * as ulid from "ulid";
+import { ulid } from "ulid";
 import * as validator from "validator";
 
 import { fromNullable, Option } from "fp-ts/lib/Option";

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "request-ip": "^2.0.2",
     "ts-is": "^1.0.0",
     "typescript": "^2.6.0",
-    "ulid": "^1.0.0",
+    "ulid": "^2.2.2",
     "unified": "^6.1.5",
     "validator": "^8.2.0",
     "vfile": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6290,9 +6290,9 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
-ulid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ulid/-/ulid-1.0.0.tgz#4748d393d138dcf497c281deefbf619286e790aa"
+ulid@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/ulid/-/ulid-2.2.2.tgz#27cfa22848a213fb31bd5bc31dfc6712c1ad1471"
 
 unc-path-regex@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
As with https://github.com/teamdigitale/digital-citizenship-functions/pull/111
I'm trying to reuse the model layer of this repository importing it to another one:

`yarn add  https://github.com/teamdigitale/digital-citizenship-functions`

Some oddities with ulid 1.x module causes errors using it with Typescript 
so I suggest to upgrade to 2.x which is a better citizen.


`node_modules/digital-citizenship-functions/lib/utils/strings.ts(2,23): error TS2497: Module '.../digital-citizenship/node_modules/ulid/index"' resolves to a non-module entity and cannot be imported using this construct.
`