### PR TITLE
fix(#153802058): documentdb types

### DIFF
--- a/lib/types/documentdb.d.ts
+++ b/lib/types/documentdb.d.ts
@@ -1,0 +1,10 @@
+import * as documentdb from "documentdb";
+
+declare module "documentdb" {
+  // [#153802058] _ts is a number but is defined as string.
+  // TODO: get rid of this file when this pull request gets merged:
+  // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22291#issuecomment-352883251
+  export interface RetrievedDocument extends NewDocument, AbstractMeta {
+    _ts: any;
+  }
+}

--- a/lib/utils/documentdb.ts
+++ b/lib/utils/documentdb.ts
@@ -65,7 +65,7 @@ export const RetrievedDocument = t.intersection([
     _self: t.string,
 
     /** The time the object was created. */
-    _ts: t.string
+    _ts: t.union([t.string, t.number])
   }),
   t.partial({
     _attachments: t.string,


### PR DESCRIPTION
this avoids patching @types/documentdb