### PR TITLE
Fix IResponse types

### DIFF
--- a/lib/controllers/adm/services.ts
+++ b/lib/controllers/adm/services.ts
@@ -137,7 +137,7 @@ function servicePayloadToService(service: ApiService): Service {
  * A middleware that extracts a Service payload from a request.
  */
 export const ServicePayloadMiddleware: IRequestMiddleware<
-  IResponseErrorValidation,
+  "IResponseErrorValidation",
   ApiService
 > = request =>
   new Promise(resolve => {

--- a/lib/controllers/messages.ts
+++ b/lib/controllers/messages.ts
@@ -109,7 +109,7 @@ interface IBindings {
  * A request middleware that validates the Message payload.
  */
 export const MessagePayloadMiddleware: IRequestMiddleware<
-  IResponseErrorValidation,
+  "IResponseErrorValidation",
   ApiNewMessage
 > = request =>
   new Promise(resolve => {

--- a/lib/controllers/profiles.ts
+++ b/lib/controllers/profiles.ts
@@ -172,7 +172,7 @@ export function GetProfile(
  * A middleware that extracts a Profile payload from a request.
  */
 export const ProfilePayloadMiddleware: IRequestMiddleware<
-  IResponseErrorValidation,
+  "IResponseErrorValidation",
   ExtendedProfile
 > = request =>
   new Promise(resolve => {

--- a/lib/utils/__tests__/request_middleware.test.ts
+++ b/lib/utils/__tests__/request_middleware.test.ts
@@ -17,7 +17,7 @@ const ResolvingMiddleware: IRequestMiddleware<never, string> = req => {
 };
 
 const RejectingMiddleware: IRequestMiddleware<
-  IResponseErrorValidation,
+  "IResponseErrorValidation",
   string
 > = _ => {
   return Promise.resolve(
@@ -33,7 +33,7 @@ const request = {
   }
 };
 
-const response = {} as IResponse;
+const response = {} as IResponse<{}>;
 
 describe("withRequestMiddlewares", () => {
   it("should process a request with a resolving middleware (1)", () => {

--- a/lib/utils/middlewares/azure_api_auth.ts
+++ b/lib/utils/middlewares/azure_api_auth.ts
@@ -103,9 +103,9 @@ function getGroupsFromHeader(groupsHeader: string): Set<UserGroup> {
 export function AzureApiAuthMiddleware(
   allowedGroups: Set<UserGroup>
 ): IRequestMiddleware<
-  | IResponseErrorForbiddenNotAuthorized
-  | IResponseErrorForbiddenAnonymousUser
-  | IResponseErrorForbiddenNoAuthorizationGroups,
+  | "IResponseErrorForbiddenNotAuthorized"
+  | "IResponseErrorForbiddenAnonymousUser"
+  | "IResponseErrorForbiddenNoAuthorizationGroups",
   IAzureApiAuthorization
 > {
   return request =>

--- a/lib/utils/middlewares/azure_user_attributes.ts
+++ b/lib/utils/middlewares/azure_user_attributes.ts
@@ -15,9 +15,6 @@ import { EmailString, NonEmptyString } from "../strings";
 import { Service, ServiceModel } from "../../models/service";
 import { IRequestMiddleware } from "../request_middleware";
 import {
-  IResponseErrorForbiddenNotAuthorized,
-  IResponseErrorInternal,
-  IResponseErrorQuery,
   ResponseErrorForbiddenNotAuthorized,
   ResponseErrorInternal,
   ResponseErrorQuery
@@ -53,9 +50,9 @@ export interface IAzureUserAttributes {
 export function AzureUserAttributesMiddleware(
   serviceModel: ServiceModel
 ): IRequestMiddleware<
-  | IResponseErrorForbiddenNotAuthorized
-  | IResponseErrorQuery
-  | IResponseErrorInternal,
+  | "IResponseErrorForbiddenNotAuthorized"
+  | "IResponseErrorQuery"
+  | "IResponseErrorInternal",
   IAzureUserAttributes
 > {
   return async request => {

--- a/lib/utils/middlewares/context_middleware.ts
+++ b/lib/utils/middlewares/context_middleware.ts
@@ -31,7 +31,7 @@ export function getAppContext<T>(
  * @param T The type of the bindings found in the context.
  */
 export function ContextMiddleware<T>(): IRequestMiddleware<
-  IResponseErrorInternal,
+  "IResponseErrorInternal",
   IContext<T>
 > {
   return request =>

--- a/lib/utils/middlewares/required_param.ts
+++ b/lib/utils/middlewares/required_param.ts
@@ -1,10 +1,7 @@
 import * as t from "io-ts";
 
 import { IRequestMiddleware } from "../request_middleware";
-import {
-  IResponseErrorValidation,
-  ResponseErrorFromValidationErrors
-} from "../response";
+import { ResponseErrorFromValidationErrors } from "../response";
 
 /**
  * Returns a request middleware that validates the presence of a required
@@ -16,7 +13,7 @@ import {
 export function RequiredParamMiddleware<S, A>(
   name: string,
   type: t.Type<S, A>
-): IRequestMiddleware<IResponseErrorValidation, A> {
+): IRequestMiddleware<"IResponseErrorValidation", A> {
   return request =>
     new Promise(resolve => {
       const validation = t.validate(request.params[name], type);

--- a/lib/utils/request_middleware.ts
+++ b/lib/utils/request_middleware.ts
@@ -5,16 +5,16 @@ import { Either, isLeft } from "fp-ts/lib/Either";
 
 import { IResponse, ResponseErrorInternal } from "./response";
 
-export type RequestHandler<R extends IResponse> = (
+export type RequestHandler<R> = (
   request: express.Request
-) => Promise<R>;
+) => Promise<IResponse<R>>;
 
 /**
  * Transforms a typesafe RequestHandler into an Express Request Handler.
  *
  * Failed promises will be mapped to 500 errors handled by ResponseErrorGeneric.
  */
-export function wrapRequestHandler<R extends IResponse>(
+export function wrapRequestHandler<R>(
   handler: RequestHandler<R>
 ): express.RequestHandler {
   return (request, response, _) => {
@@ -48,9 +48,9 @@ export function wrapRequestHandler<R extends IResponse>(
  * the response objects. Access to the response object is particulary useful
  * for returning error messages when the validation fails.
  */
-export type IRequestMiddleware<R extends IResponse, T> = (
+export type IRequestMiddleware<R, T> = (
   request: express.Request
-) => Promise<Either<R, T>>;
+) => Promise<Either<IResponse<R>, T>>;
 
 //
 // The following are the type definitions for withRequestMiddlewares(...)
@@ -60,67 +60,41 @@ export type IRequestMiddleware<R extends IResponse, T> = (
 // and each parameter must be of the same type returned by the corresponding middleware.
 //
 
-export function withRequestMiddlewares<
-  RH extends IResponse,
-  R1 extends IResponse,
-  T1
->(
+export function withRequestMiddlewares<RH, R1, T1>(
   v1: IRequestMiddleware<R1, T1>
-): (handler: (v1: T1) => Promise<RH>) => RequestHandler<RH | R1>;
+): (handler: (v1: T1) => Promise<IResponse<RH>>) => RequestHandler<RH | R1>;
 
-export function withRequestMiddlewares<
-  RH extends IResponse,
-  R1 extends IResponse,
-  R2 extends IResponse,
-  T1,
-  T2
->(
+export function withRequestMiddlewares<RH, R1, R2, T1, T2>(
   v1: IRequestMiddleware<R1, T1>,
   v2: IRequestMiddleware<R2, T2>
-): (handler: (v1: T1, v2: T2) => Promise<RH>) => RequestHandler<RH | R1 | R2>;
+): (
+  handler: (v1: T1, v2: T2) => Promise<IResponse<RH>>
+) => RequestHandler<RH | R1 | R2>;
 
-export function withRequestMiddlewares<
-  RH extends IResponse,
-  R1 extends IResponse,
-  R2 extends IResponse,
-  R3 extends IResponse,
-  T1,
-  T2,
-  T3
->(
+export function withRequestMiddlewares<RH, R1, R2, R3, T1, T2, T3>(
   v1: IRequestMiddleware<R1, T1>,
   v2: IRequestMiddleware<R2, T2>,
   v3: IRequestMiddleware<R3, T3>
 ): (
-  handler: (v1: T1, v2: T2, v3: T3) => Promise<RH>
+  handler: (v1: T1, v2: T2, v3: T3) => Promise<IResponse<RH>>
 ) => RequestHandler<RH | R1 | R2 | R3>;
 
-export function withRequestMiddlewares<
-  RH extends IResponse,
-  R1 extends IResponse,
-  R2 extends IResponse,
-  R3 extends IResponse,
-  R4 extends IResponse,
-  T1,
-  T2,
-  T3,
-  T4
->(
+export function withRequestMiddlewares<RH, R1, R2, R3, R4, T1, T2, T3, T4>(
   v1: IRequestMiddleware<R1, T1>,
   v2: IRequestMiddleware<R2, T2>,
   v3: IRequestMiddleware<R3, T3>,
   v4: IRequestMiddleware<R4, T4>
 ): (
-  handler: (v1: T1, v2: T2, v3: T3, v4: T4) => Promise<RH>
+  handler: (v1: T1, v2: T2, v3: T3, v4: T4) => Promise<IResponse<RH>>
 ) => RequestHandler<RH | R1 | R2 | R3 | R4>;
 
 export function withRequestMiddlewares<
-  RH extends IResponse,
-  R1 extends IResponse,
-  R2 extends IResponse,
-  R3 extends IResponse,
-  R4 extends IResponse,
-  R5 extends IResponse,
+  RH,
+  R1,
+  R2,
+  R3,
+  R4,
+  R5,
   T1,
   T2,
   T3,
@@ -133,17 +107,17 @@ export function withRequestMiddlewares<
   v4: IRequestMiddleware<R4, T4>,
   v5: IRequestMiddleware<R5, T5>
 ): (
-  handler: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5) => Promise<RH>
+  handler: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5) => Promise<IResponse<RH>>
 ) => RequestHandler<RH | R1 | R2 | R3 | R4 | R5>;
 
 export function withRequestMiddlewares<
-  RH extends IResponse,
-  R1 extends IResponse,
-  R2 extends IResponse,
-  R3 extends IResponse,
-  R4 extends IResponse,
-  R5 extends IResponse,
-  R6 extends IResponse,
+  RH,
+  R1,
+  R2,
+  R3,
+  R4,
+  R5,
+  R6,
   T1,
   T2,
   T3,
@@ -158,7 +132,14 @@ export function withRequestMiddlewares<
   v5: IRequestMiddleware<R5, T5>,
   v6: IRequestMiddleware<R6, T6>
 ): (
-  handler: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => Promise<RH>
+  handler: (
+    v1: T1,
+    v2: T2,
+    v3: T3,
+    v4: T4,
+    v5: T5,
+    v6: T6
+  ) => Promise<IResponse<RH>>
 ) => RequestHandler<RH | R1 | R2 | R3 | R4 | R5 | R6>;
 
 /**
@@ -173,13 +154,13 @@ export function withRequestMiddlewares<
  * That final response gets sent to the client.
  */
 export function withRequestMiddlewares<
-  RH extends IResponse,
-  R1 extends IResponse,
-  R2 extends IResponse,
-  R3 extends IResponse,
-  R4 extends IResponse,
-  R5 extends IResponse,
-  R6 extends IResponse,
+  RH,
+  R1,
+  R2,
+  R3,
+  R4,
+  R5,
+  R6,
   T1,
   T2,
   T3,
@@ -194,108 +175,120 @@ export function withRequestMiddlewares<
   v5?: IRequestMiddleware<R5, T5>,
   v6?: IRequestMiddleware<R6, T6>
 ): (
-  handler: (v1: T1, v2?: T2, v3?: T3, v4?: T4, v5?: T5, v6?: T6) => Promise<RH>
+  handler: (
+    v1: T1,
+    v2?: T2,
+    v3?: T3,
+    v4?: T4,
+    v5?: T5,
+    v6?: T6
+  ) => Promise<IResponse<RH>>
 ) => RequestHandler<R1 | R2 | R3 | R4 | R5 | R6 | RH> {
   return handler => {
     // The outer promise with resolve to a type that can either be the the type returned
     // by the handler or one of the types returned by any of the middlewares (i.e., when
     // a middleware returns an error response).
     return request =>
-      new Promise<R1 | R2 | R3 | R4 | R5 | R6 | RH>((resolve, reject) => {
-        // we execute each middleware in sequence, stopping at the first middleware that is
-        // undefined or when a middleware returns an error response.
-        // when we find an undefined middleware, we call the handler with all the results of
-        // the executed middlewares
-        v1(request).then(r1 => {
-          if (isLeft(r1)) {
-            // 1st middleware returned a response
-            // stop processing the middlewares
-            resolve(r1.value);
-          } else if (v2 !== undefined) {
-            // 1st middleware returned a value
-            // process 2nd middleware
-            v2(request).then(r2 => {
-              if (isLeft(r2)) {
-                // 2nd middleware returned a response
-                // stop processing the middlewares
-                resolve(r2.value);
-              } else if (v3 !== undefined) {
-                // process 3rd middleware
-                v3(request).then(r3 => {
-                  if (isLeft(r3)) {
-                    // 3rd middleware returned a response
-                    // stop processing the middlewares
-                    resolve(r3.value);
-                  } else if (v4 !== undefined) {
-                    v4(request).then(r4 => {
-                      if (isLeft(r4)) {
-                        // 4th middleware returned a response
-                        // stop processing the middlewares
-                        resolve(r4.value);
-                      } else if (v5 !== undefined) {
-                        v5(request).then(r5 => {
-                          if (isLeft(r5)) {
-                            // 5th middleware returned a response
-                            // stop processing the middlewares
-                            resolve(r5.value);
-                          } else if (v6 !== undefined) {
-                            v6(request).then(r6 => {
-                              if (isLeft(r6)) {
-                                // 6th middleware returned a response
-                                // stop processing the middlewares
-                                resolve(r6.value);
-                              } else {
-                                // 6th middleware returned a value
-                                // run handler
-                                handler(
-                                  r1.value,
-                                  r2.value,
-                                  r3.value,
-                                  r4.value,
-                                  r5.value,
-                                  r6.value
-                                ).then(resolve, reject);
-                              }
-                            }, reject);
-                          } else {
-                            // 5th middleware returned a value
-                            // run handler
-                            handler(
-                              r1.value,
-                              r2.value,
-                              r3.value,
-                              r4.value,
-                              r5.value
-                            ).then(resolve, reject);
-                          }
-                        }, reject);
-                      } else {
-                        // 4th middleware returned a value
-                        // run handler
-                        handler(r1.value, r2.value, r3.value, r4.value).then(
-                          resolve,
-                          reject
-                        );
-                      }
-                    }, reject);
-                  } else {
-                    // 3rd middleware returned a value
-                    // run handler
-                    handler(r1.value, r2.value, r3.value).then(resolve, reject);
-                  }
-                }, reject);
-              } else {
-                // 2nd middleware returned a value
-                // run handler
-                handler(r1.value, r2.value).then(resolve, reject);
-              }
-            }, reject);
-          } else {
-            // 1st middleware returned a value
-            // run handler
-            handler(r1.value).then(resolve, reject);
-          }
-        }, reject);
-      });
+      new Promise<IResponse<R1 | R2 | R3 | R4 | R5 | R6 | RH>>(
+        (resolve, reject) => {
+          // we execute each middleware in sequence, stopping at the first middleware that is
+          // undefined or when a middleware returns an error response.
+          // when we find an undefined middleware, we call the handler with all the results of
+          // the executed middlewares
+          v1(request).then(r1 => {
+            if (isLeft(r1)) {
+              // 1st middleware returned a response
+              // stop processing the middlewares
+              resolve(r1.value);
+            } else if (v2 !== undefined) {
+              // 1st middleware returned a value
+              // process 2nd middleware
+              v2(request).then(r2 => {
+                if (isLeft(r2)) {
+                  // 2nd middleware returned a response
+                  // stop processing the middlewares
+                  resolve(r2.value);
+                } else if (v3 !== undefined) {
+                  // process 3rd middleware
+                  v3(request).then(r3 => {
+                    if (isLeft(r3)) {
+                      // 3rd middleware returned a response
+                      // stop processing the middlewares
+                      resolve(r3.value);
+                    } else if (v4 !== undefined) {
+                      v4(request).then(r4 => {
+                        if (isLeft(r4)) {
+                          // 4th middleware returned a response
+                          // stop processing the middlewares
+                          resolve(r4.value);
+                        } else if (v5 !== undefined) {
+                          v5(request).then(r5 => {
+                            if (isLeft(r5)) {
+                              // 5th middleware returned a response
+                              // stop processing the middlewares
+                              resolve(r5.value);
+                            } else if (v6 !== undefined) {
+                              v6(request).then(r6 => {
+                                if (isLeft(r6)) {
+                                  // 6th middleware returned a response
+                                  // stop processing the middlewares
+                                  resolve(r6.value);
+                                } else {
+                                  // 6th middleware returned a value
+                                  // run handler
+                                  handler(
+                                    r1.value,
+                                    r2.value,
+                                    r3.value,
+                                    r4.value,
+                                    r5.value,
+                                    r6.value
+                                  ).then(resolve, reject);
+                                }
+                              }, reject);
+                            } else {
+                              // 5th middleware returned a value
+                              // run handler
+                              handler(
+                                r1.value,
+                                r2.value,
+                                r3.value,
+                                r4.value,
+                                r5.value
+                              ).then(resolve, reject);
+                            }
+                          }, reject);
+                        } else {
+                          // 4th middleware returned a value
+                          // run handler
+                          handler(r1.value, r2.value, r3.value, r4.value).then(
+                            resolve,
+                            reject
+                          );
+                        }
+                      }, reject);
+                    } else {
+                      // 3rd middleware returned a value
+                      // run handler
+                      handler(r1.value, r2.value, r3.value).then(
+                        resolve,
+                        reject
+                      );
+                    }
+                  }, reject);
+                } else {
+                  // 2nd middleware returned a value
+                  // run handler
+                  handler(r1.value, r2.value).then(resolve, reject);
+                }
+              }, reject);
+            } else {
+              // 1st middleware returned a value
+              // run handler
+              handler(r1.value).then(resolve, reject);
+            }
+          }, reject);
+        }
+      );
   };
 }

--- a/lib/utils/response.ts
+++ b/lib/utils/response.ts
@@ -19,8 +19,8 @@ const HTTP_STATUS_500 = 500 as HttpStatusCode;
  * Interface for a Response that can be returned by a middleware or
  * by the handlers.
  */
-export interface IResponse {
-  readonly kind: string;
+export interface IResponse<T> {
+  readonly kind: T;
   readonly apply: (response: express.Response) => void;
 }
 
@@ -31,8 +31,8 @@ export interface IResponse {
 /**
  * Interface for a successful response returning a json object.
  */
-export interface IResponseSuccessJson<T> extends IResponse {
-  readonly kind: "IResponseSuccessJson";
+export interface IResponseSuccessJson<T>
+  extends IResponse<"IResponseSuccessJson"> {
   readonly value: T; // needed to discriminate from other T subtypes
 }
 
@@ -55,8 +55,8 @@ export function ResponseSuccessJson<T>(o: T): IResponseSuccessJson<T> {
 /**
  * Interface for a successful response returning a json object.
  */
-export interface IResponseSuccessJsonIterator<T> extends IResponse {
-  readonly kind: "IResponseSuccessJsonIterator";
+export interface IResponseSuccessJsonIterator<T>
+  extends IResponse<"IResponseSuccessJsonIterator"> {
   readonly value: T; // needed to discriminate from other T subtypes
 }
 
@@ -86,8 +86,8 @@ export function ResponseSuccessJsonIterator<T>(
 /**
  * Interface for a successful response returning a redirect to a resource.
  */
-export interface IResponseSuccessRedirectToResource<T, V> extends IResponse {
-  readonly kind: "IResponseSuccessRedirectToResource";
+export interface IResponseSuccessRedirectToResource<T, V>
+  extends IResponse<"IResponseSuccessRedirectToResource"> {
   readonly resource: T; // type checks the right kind of resource
   readonly payload: V;
 }
@@ -119,9 +119,7 @@ export function ResponseSuccessRedirectToResource<T, V>(
 /**
  * Interface for a response describing a generic server error.
  */
-interface IResponseErrorGeneric extends IResponse {
-  readonly kind: "IResponseErrorGeneric";
-}
+interface IResponseErrorGeneric extends IResponse<"IResponseErrorGeneric"> {}
 
 /**
  * Returns a response describing a generic error.
@@ -155,9 +153,8 @@ function ResponseErrorGeneric(
 /**
  * Interface for a response describing a 404 error.
  */
-export interface IResponseErrorNotFound extends IResponse {
-  readonly kind: "IResponseErrorNotFound";
-}
+export interface IResponseErrorNotFound
+  extends IResponse<"IResponseErrorNotFound"> {}
 
 /**
  * Returns a response describing a 404 error.
@@ -177,9 +174,8 @@ export function ResponseErrorNotFound(
 /**
  * Interface for a response describing a validation error.
  */
-export interface IResponseErrorValidation extends IResponse {
-  readonly kind: "IResponseErrorValidation";
-}
+export interface IResponseErrorValidation
+  extends IResponse<"IResponseErrorValidation"> {}
 
 /**
  * Returns a response describing a validation error.
@@ -209,9 +205,8 @@ export function ResponseErrorFromValidationErrors<S, A>(
 /**
  * The user is not allowed here.
  */
-export interface IResponseErrorForbiddenNotAuthorized extends IResponse {
-  readonly kind: "IResponseErrorForbiddenNotAuthorized";
-}
+export interface IResponseErrorForbiddenNotAuthorized
+  extends IResponse<"IResponseErrorForbiddenNotAuthorized"> {}
 
 /**
  * The user is not allowed here.
@@ -229,9 +224,7 @@ export const ResponseErrorForbiddenNotAuthorized: IResponseErrorForbiddenNotAuth
  * The user is not allowed to issue production requests.
  */
 export interface IResponseErrorForbiddenNotAuthorizedForProduction
-  extends IResponse {
-  readonly kind: "IResponseErrorForbiddenNotAuthorizedForProduction";
-}
+  extends IResponse<"IResponseErrorForbiddenNotAuthorizedForProduction"> {}
 
 /**
  * The user is not allowed to issue production requests.
@@ -249,9 +242,7 @@ export const ResponseErrorForbiddenNotAuthorizedForProduction: IResponseErrorFor
  * The user is not allowed to issue requests for the recipient.
  */
 export interface IResponseErrorForbiddenNotAuthorizedForRecipient
-  extends IResponse {
-  readonly kind: "IResponseErrorForbiddenNotAuthorizedForRecipient";
-}
+  extends IResponse<"IResponseErrorForbiddenNotAuthorizedForRecipient"> {}
 
 /**
  * The user is not allowed to issue requests for the recipient.
@@ -269,9 +260,9 @@ export const ResponseErrorForbiddenNotAuthorizedForRecipient: IResponseErrorForb
  * The user is not allowed to send messages with default addresses.
  */
 export interface IResponseErrorForbiddenNotAuthorizedForDefaultAddresses
-  extends IResponse {
-  readonly kind: "IResponseErrorForbiddenNotAuthorizedForDefaultAddresses";
-}
+  extends IResponse<
+      "IResponseErrorForbiddenNotAuthorizedForDefaultAddresses"
+    > {}
 
 /**
  * The user is not allowed to send messages with default addresses.
@@ -288,9 +279,8 @@ export const ResponseErrorForbiddenNotAuthorizedForDefaultAddresses: IResponseEr
 /**
  * The user is anonymous.
  */
-export interface IResponseErrorForbiddenAnonymousUser extends IResponse {
-  readonly kind: "IResponseErrorForbiddenAnonymousUser";
-}
+export interface IResponseErrorForbiddenAnonymousUser
+  extends IResponse<"IResponseErrorForbiddenAnonymousUser"> {}
 
 /**
  * The user is anonymous.
@@ -308,9 +298,7 @@ export const ResponseErrorForbiddenAnonymousUser: IResponseErrorForbiddenAnonymo
  * The user is not part of any valid authorization groups.
  */
 export interface IResponseErrorForbiddenNoAuthorizationGroups
-  extends IResponse {
-  readonly kind: "IResponseErrorForbiddenNoAuthorizationGroups";
-}
+  extends IResponse<"IResponseErrorForbiddenNoAuthorizationGroups"> {}
 
 /**
  * The user is not part of any valid authorization groups.
@@ -327,9 +315,7 @@ export const ResponseErrorForbiddenNoAuthorizationGroups: IResponseErrorForbidde
 /**
  * Interface for a response describing a database error.
  */
-export interface IResponseErrorQuery extends IResponse {
-  readonly kind: "IResponseErrorQuery";
-}
+export interface IResponseErrorQuery extends IResponse<"IResponseErrorQuery"> {}
 
 /**
  * Returns a response describing a database error.
@@ -354,9 +340,8 @@ export function ResponseErrorQuery(
 /**
  * Interface for a response describing an internal server error.
  */
-export interface IResponseErrorInternal extends IResponse {
-  readonly kind: "IResponseErrorInternal";
-}
+export interface IResponseErrorInternal
+  extends IResponse<"IResponseErrorInternal"> {}
 
 /**
  * Returns a response describing an internal server error.


### PR DESCRIPTION
While I was writing an article describing the technique we implemented, I realized the code I wrote wasn't correct, `IResponse` was defined with the `kind` attribute of type `string` when instead the `kind` attribute has the type that names the kind of response (e.g. `IResponseNotFound`), `IResponse` should have a type parameter that is the type of `kind`.