### PR TITLE
[#150597257] - schedule retries when a queue action fails

### DIFF
--- a/host.json
+++ b/host.json
@@ -6,6 +6,13 @@
     "maxConcurrentRequests": 50,
     "dynamicThrottlesEnabled": false
   },
+  "queues": {
+    "maxPollingInterval": 10000,
+    "visibilityTimeout" : "00:00:30",
+    "batchSize": 16,
+    "maxDequeueCount": 22,
+    "newBatchThreshold": 8
+  },
   "functions": [
     "PublicApiV1",
     "Openapi",

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -20,7 +20,11 @@ import * as documentDbUtils from "./utils/documentdb";
 
 import { fromNullable, isNone, Option } from "fp-ts/lib/Option";
 
-import { BlobService, createBlobService } from "azure-storage";
+import {
+  BlobService,
+  createBlobService,
+  createQueueService
+} from "azure-storage";
 
 import { MessageContent } from "./api/definitions/MessageContent";
 import { NewMessageDefaultAddresses } from "./api/definitions/NewMessageDefaultAddresses";
@@ -29,7 +33,6 @@ import { NotificationChannelStatusEnum } from "./api/definitions/NotificationCha
 import { getRequiredStringEnv } from "./utils/env";
 
 import { CreatedMessageEvent } from "./models/created_message_event";
-import { CreatedMessageEventSenderMetadata } from "./models/created_message_sender_metadata";
 import { MessageModel, NewMessageWithoutContent } from "./models/message";
 import {
   NewNotification,
@@ -39,22 +42,30 @@ import {
   RetrievedNotification
 } from "./models/notification";
 import { NotificationEvent } from "./models/notification_event";
-import { ProfileModel } from "./models/profile";
+import { ProfileModel, RetrievedProfile } from "./models/profile";
 
 import { Either, isLeft, isRight, left, right } from "fp-ts/lib/Either";
 import { NonEmptyString } from "./utils/strings";
 import { Tuple2 } from "./utils/tuples";
 import { ReadableReporter } from "./utils/validation_reporters";
 
+import { retryMessageEnqueue } from "./utils/azure_queues";
+import {
+  isTransient,
+  PermanentError,
+  RuntimeError,
+  TransientError
+} from "./utils/errors";
+
+import { CreatedMessageEventSenderMetadata } from "./models/created_message_sender_metadata";
+
 // Whether we're in a production environment
 const isProduction = process.env.NODE_ENV === "production";
 
 // Setup DocumentDB
-
 const cosmosDbUri = getRequiredStringEnv("CUSTOMCONNSTR_COSMOSDB_URI");
 const cosmosDbKey = getRequiredStringEnv("CUSTOMCONNSTR_COSMOSDB_KEY");
 const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
-const messageContainerName = getRequiredStringEnv("MESSAGE_CONTAINER_NAME");
 
 const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
 const profilesCollectionUrl = documentDbUtils.getCollectionUri(
@@ -70,7 +81,12 @@ const notificationsCollectionUrl = documentDbUtils.getCollectionUri(
   "notifications"
 );
 
+// must be equal to the queue name in function.json
+export const MESSAGE_QUEUE_NAME = "createdmessages";
+
+const messageContainerName = getRequiredStringEnv("MESSAGE_CONTAINER_NAME");
 const storageConnectionString = getRequiredStringEnv("QueueStorageConnection");
+const queueConnectionString = getRequiredStringEnv("QueueStorageConnection");
 
 /**
  * Input and output bindings for this function
@@ -90,15 +106,30 @@ const ContextWithBindings = t.interface({
 type ContextWithBindings = t.TypeOf<typeof ContextWithBindings> & IContext;
 
 /**
- * Bad things that can happen while we process the message
+ * Attempt to resolve an email address from the recipient profile
+ * or from a provided default address.
+ *
+ * @param maybeProfile      the recipient's profile (or none)
+ * @param defaultAddresses  default addresses (one per channel)
  */
-export enum ProcessingError {
-  // a transient error, e.g. database is not available
-  TRANSIENT,
-
-  // user has no profile and no default addresses have been provided,
-  // we can't deliver a notification
-  NO_ADDRESSES
+function getEmailNotification(
+  maybeProfile: Option<RetrievedProfile>,
+  defaultAddresses: Option<NewMessageDefaultAddresses>
+): Option<NotificationChannelEmail> {
+  const maybeProfileEmail = maybeProfile
+    .chain(profile => fromNullable(profile.email))
+    .map(email => Tuple2(email, NotificationAddressSourceEnum.PROFILE_ADDRESS));
+  const maybeDefaultEmail = defaultAddresses
+    .chain(addresses => fromNullable(addresses.email))
+    .map(email => Tuple2(email, NotificationAddressSourceEnum.DEFAULT_ADDRESS));
+  const maybeEmail = maybeProfileEmail.alt(maybeDefaultEmail);
+  return maybeEmail.map(({ e1: toAddress, e2: addressSource }) => {
+    return {
+      addressSource,
+      status: NotificationChannelStatusEnum.QUEUED,
+      toAddress
+    };
+  });
 }
 
 /**
@@ -106,6 +137,9 @@ export enum ProcessingError {
  * creating a Notification record that has all the channels configured.
  *
  * TODO: emit to all channels (push notification, sms, etc...)
+ *
+ * Returns left(TransientError) in case of recoverable errors.
+ * Returns left(Error) in case of permanent errors.
  */
 export async function handleMessage(
   profileModel: ProfileModel,
@@ -115,7 +149,7 @@ export async function handleMessage(
   newMessageWithoutContent: NewMessageWithoutContent,
   messageContent: MessageContent,
   defaultAddresses: Option<NewMessageDefaultAddresses>
-): Promise<Either<ProcessingError, RetrievedNotification>> {
+): Promise<Either<RuntimeError, RetrievedNotification>> {
   // async fetch of profile data associated to the fiscal code the message
   // should be delivered to
   const errorOrMaybeProfile = await profileModel.findOneProfileByFiscalCode(
@@ -123,8 +157,10 @@ export async function handleMessage(
   );
 
   if (isLeft(errorOrMaybeProfile)) {
-    // query failed
-    return left(ProcessingError.TRANSIENT);
+    // The query has failed.
+    // It's critical to trigger a retry here
+    // otherwise no message content will be saved
+    return left(TransientError("Cannot get user's profile"));
   }
 
   // query succeeded, we may have a profile
@@ -136,8 +172,10 @@ export async function handleMessage(
   );
 
   if (isMessageStorageEnabled) {
-    // if the recipient wants to store the messages
-    // we add the content of the message to the blob storage for later retrieval
+    // If the recipient wants to store the messages
+    // we add the content of the message to the blob storage for later retrieval.
+    // In case of a retry this operation will overwrite the message content with itself
+    // (this is fine as we don't know if the operation succeeded at first)
     const errorOrAttachment = await messageModel.attachStoredContent(
       blobService,
       newMessageWithoutContent.id,
@@ -145,39 +183,34 @@ export async function handleMessage(
       messageContent
     );
 
-    winston.debug(`handleMessage|${JSON.stringify(newMessageWithoutContent)}`);
+    winston.debug(
+      `handleMessage|attachStoredContent|${JSON.stringify(
+        newMessageWithoutContent
+      )}`
+    );
 
     if (isLeft(errorOrAttachment)) {
       winston.error(`handleMessage|${JSON.stringify(errorOrAttachment)}`);
-      // we consider errors while updating message as transient
-      return left(ProcessingError.TRANSIENT);
+      return left(TransientError("Cannot store message content"));
     }
   }
 
-  //
   // attempt to resolve an email notification
-  //
-  const maybeProfileEmail = maybeProfile
-    .chain(profile => fromNullable(profile.email))
-    .map(email => Tuple2(email, NotificationAddressSourceEnum.PROFILE_ADDRESS));
-  const maybeDefaultEmail = defaultAddresses
-    .chain(addresses => fromNullable(addresses.email))
-    .map(email => Tuple2(email, NotificationAddressSourceEnum.DEFAULT_ADDRESS));
-  const maybeEmail = maybeProfileEmail.alt(maybeDefaultEmail);
-  const maybeEmailNotification: Option<
-    NotificationChannelEmail
-  > = maybeEmail.map(({ e1: toAddress, e2: addressSource }) => {
-    return {
-      addressSource,
-      status: NotificationChannelStatusEnum.QUEUED,
-      toAddress
-    };
-  });
+  const maybeEmailNotification = getEmailNotification(
+    maybeProfile,
+    defaultAddresses
+  );
 
   // check whether there's at least a channel we can send the notification to
   if (isNone(maybeEmailNotification)) {
     // no channels to notify the user
-    return left(ProcessingError.NO_ADDRESSES);
+    return left(
+      PermanentError(
+        `Fiscal code has no associated email address and no default addresses was provided|${
+          newMessageWithoutContent.fiscalCode
+        }`
+      )
+    );
   }
 
   // create a new Notification object with the configured notification channels
@@ -200,9 +233,7 @@ export async function handleMessage(
   );
 
   if (isLeft(result)) {
-    // saved failed, fail with a transient error
-    // TODO: we could check the error to see if it's actually transient
-    return left(ProcessingError.TRANSIENT);
+    return left(TransientError("Cannot save notification to database"));
   }
 
   // save succeeded, return the saved Notification
@@ -210,20 +241,17 @@ export async function handleMessage(
 }
 
 export function processResolve(
-  errorOrNotification: Either<ProcessingError, RetrievedNotification>,
+  errorOrNotification: Either<RuntimeError, RetrievedNotification>,
   context: ContextWithBindings,
-  newMessageWithoutContent: NewMessageWithoutContent,
   messageContent: MessageContent,
   senderMetadata: CreatedMessageEventSenderMetadata
 ): void {
   if (isRight(errorOrNotification)) {
-    // the notification has been created
     const notification = errorOrNotification.value;
-
+    // TODO: handle all notification channels
+    // the notification object has been created with an email channel
+    // we output a notification event to the email channel queue
     if (notification.emailNotification) {
-      // the notification object has been created with an email channel
-      // we output a notification event to the email channel queue
-
       // tslint:disable-next-line:no-object-mutation
       context.bindings.emailNotification = {
         messageContent,
@@ -232,144 +260,135 @@ export function processResolve(
         senderMetadata
       };
     }
-
-    context.done();
+    // TODO: update message status (queued_at)
+  } else if (isTransient(errorOrNotification.value)) {
+    const transientError = errorOrNotification.value;
+    winston.error(
+      `CreatedMessageQueueHandler|Transient error|${transientError.message}`
+    );
+    // schedule a retry in case of transient errors
+    // retry function is async and calls context.done() by itself
+    const queueService = createQueueService(queueConnectionString);
+    return retryMessageEnqueue(queueService, MESSAGE_QUEUE_NAME, context);
   } else {
-    // the processing failed
-    switch (errorOrNotification.value) {
-      case ProcessingError.NO_ADDRESSES: {
-        winston.error(
-          `Fiscal code has no associated profile and no default addresses provided|${
-            newMessageWithoutContent.fiscalCode
-          }`
-        );
-        context.done();
-        break;
-      }
-      case ProcessingError.TRANSIENT: {
-        winston.error(
-          `Transient error, retrying|${newMessageWithoutContent.fiscalCode}`
-        );
-        context.done("Transient error"); // here we trigger a retry by calling
-        // done(error)
-        break;
-      }
-    }
+    // the processing failed with an unrecoverable error
+    // TODO: update message status (failed_at)
+    const permanentError = errorOrNotification.value;
+    winston.error(
+      `CreatedMessageQueueHandler|Permanent error|${permanentError.message}`
+    );
   }
-}
-
-export function processReject(
-  context: ContextWithBindings,
-  newMessageWithoutContent: NewMessageWithoutContent,
-  error: Either<ProcessingError, RetrievedNotification>
-): void {
-  // the promise failed
-  winston.error(
-    `Error while processing event, retrying|${
-      newMessageWithoutContent.fiscalCode
-    }|${error}`
-  );
-  // in case of error, we return a failure to trigger a retry (up to the
-  // configured max retries) TODO: schedule next retry with exponential
-  // backoff, see #150597257
-  context.done(error);
+  return context.done();
 }
 
 /**
  * Handler that gets triggered on incoming event.
  */
 export function index(context: ContextWithBindings): void {
-  // redirect winston logs to Azure Functions log
-  const logLevel = isProduction ? "info" : "debug";
-  configureAzureContextTransport(context, winston, logLevel);
-  winston.debug(
-    `CreatedMessageQueueHandlerIndex|bindings|${JSON.stringify(
-      context.bindings
-    )}`
-  );
+  try {
+    // redirect winston logs to Azure Functions log
+    const logLevel = isProduction ? "info" : "debug";
+    configureAzureContextTransport(context, winston, logLevel);
 
-  const createdMessageEvent = context.bindings.createdMessage;
-
-  // since this function gets triggered by a queued message that gets
-  // deserialized from a json object, we must first check that what we
-  // got is what we expect.
-  if (!CreatedMessageEvent.is(createdMessageEvent)) {
-    winston.error(`Fatal! No valid message found in bindings.`);
-
-    const validation = t.validate(createdMessageEvent, CreatedMessageEvent);
     winston.debug(
-      `CreatedMessageQueueHandlerIndex|validationError|${ReadableReporter.report(
-        validation
-      ).join("\n")}`
+      `CreatedMessageQueueHandler|queueMessage|${context.bindings}`
     );
 
-    // we will never be able to recover from this, so don't trigger an error
-    // TODO: perhaps forward this message to a failed events queue for review
-    context.done();
-    return;
-  }
-
-  // it is an CreatedMessageEvent
-  const newMessageWithoutContent = createdMessageEvent.message;
-  const messageContent = createdMessageEvent.messageContent;
-  const defaultAddresses = fromNullable(createdMessageEvent.defaultAddresses);
-  const senderMetadata = createdMessageEvent.senderMetadata;
-
-  winston.info(
-    `A new message was created|${newMessageWithoutContent.id}|${
-      newMessageWithoutContent.fiscalCode
-    }`
-  );
-
-  // setup required models
-  const documentClient = new DocumentDBClient(cosmosDbUri, {
-    masterKey: cosmosDbKey
-  });
-  const profileModel = new ProfileModel(documentClient, profilesCollectionUrl);
-  const messageModel = new MessageModel(
-    documentClient,
-    messagesCollectionUrl,
-    messageContainerName
-  );
-  const notificationModel = new NotificationModel(
-    documentClient,
-    notificationsCollectionUrl
-  );
-
-  const blobService = createBlobService(storageConnectionString);
-
-  // now we can trigger the notifications for the message
-  handleMessage(
-    profileModel,
-    messageModel,
-    notificationModel,
-    blobService,
-    newMessageWithoutContent,
-    messageContent,
-    defaultAddresses
-  ).then(
-    (errorOrNotification: Either<ProcessingError, RetrievedNotification>) => {
-      processResolve(
-        errorOrNotification,
-        context,
-        newMessageWithoutContent,
-        messageContent,
-        senderMetadata
+    // since this function gets triggered by a queued message that gets
+    // deserialized from a json object, we must first check that what we
+    // got is what we expect.
+    const validation = t.validate(
+      context.bindings.createdMessage,
+      CreatedMessageEvent
+    );
+    if (isLeft(validation)) {
+      winston.error(
+        `CreatedMessageQueueHandler|Fatal! No valid message found in bindings.`
       );
-    },
-    (error: Either<ProcessingError, RetrievedNotification>) => {
-      processReject(context, newMessageWithoutContent, error);
+      winston.debug(
+        `CreatedMessageQueueHandler|validationError|${ReadableReporter.report(
+          validation
+        ).join("\n")}`
+      );
+      // we will never be able to recover from this, so don't trigger an error
+      // TODO: update message status (failed_at)
+      return context.done();
     }
-  );
-}
 
-/*
-2017-08-14T13:58:19.356 Queue trigger function processed work item { messageId: '5991ac7944430d3670b81b74' }
-2017-08-14T13:58:19.356 queueTrigger = {"messageId":"5991ac7944430d3670b81b74"}
-2017-08-14T13:58:19.356 expirationTime = 8/21/2017 1:58:17 PM +00:00
-2017-08-14T13:58:19.356 insertionTime = 8/14/2017 1:58:17 PM +00:00
-2017-08-14T13:58:19.356 nextVisibleTime = 8/14/2017 2:08:19 PM +00:00
-2017-08-14T13:58:19.356 id= 5f149158-92fa-4aaf-84c9-667750fdfaad
-2017-08-14T13:58:19.356 popReceipt = AgAAAAMAAAAAAAAAtS7dxwYV0wE=
-2017-08-14T13:58:19.356 dequeueCount = 1
-*/
+    const createdMessageEvent = validation.value;
+
+    // it is an CreatedMessageEvent
+    const newMessageWithoutContent = createdMessageEvent.message;
+    const messageContent = createdMessageEvent.messageContent;
+    const defaultAddresses = fromNullable(createdMessageEvent.defaultAddresses);
+    const senderMetadata = createdMessageEvent.senderMetadata;
+
+    winston.info(
+      `CreatedMessageQueueHandler|A new message was created|${
+        newMessageWithoutContent.id
+      }|${newMessageWithoutContent.fiscalCode}`
+    );
+
+    // setup required models
+    const documentClient = new DocumentDBClient(cosmosDbUri, {
+      masterKey: cosmosDbKey
+    });
+    const profileModel = new ProfileModel(
+      documentClient,
+      profilesCollectionUrl
+    );
+    const messageModel = new MessageModel(
+      documentClient,
+      messagesCollectionUrl,
+      messageContainerName
+    );
+    const notificationModel = new NotificationModel(
+      documentClient,
+      notificationsCollectionUrl
+    );
+
+    const blobService = createBlobService(storageConnectionString);
+
+    // now we can trigger the notifications for the message
+    handleMessage(
+      profileModel,
+      messageModel,
+      notificationModel,
+      blobService,
+      newMessageWithoutContent,
+      messageContent,
+      defaultAddresses
+    )
+      .then(errorOrNotification => {
+        return processResolve(
+          errorOrNotification,
+          context,
+          messageContent,
+          senderMetadata
+        );
+      })
+      .catch(error => {
+        // Some unexpected exception occurred inside the promise.
+        // We consider this event as a permanent unrecoverable error.
+        // TODO: update message status (failed_at)
+        winston.error(
+          `CreatedMessageQueueHandler|Unexpected error|${
+            newMessageWithoutContent.id
+          }|${newMessageWithoutContent.fiscalCode}|${error.message}|${
+            error.stack
+          }`
+        );
+        context.done();
+      });
+  } catch (error) {
+    // Avoid poison queue in case of unexpected errors occurred outside handleMessage()
+    // (shouldn't happen)
+    // TODO: update message status (failed_at)
+    winston.error(
+      `CreatedMessageQueueHandler|Exception caught|${error.message}|${
+        error.stack
+      }`
+    );
+    context.done();
+  }
+}

--- a/lib/types/json.d.ts
+++ b/lib/types/json.d.ts
@@ -1,0 +1,4 @@
+declare module "*.json" {
+  const value: any;
+  export default value;
+}

--- a/lib/utils/__tests__/azure_queues.test.ts
+++ b/lib/utils/__tests__/azure_queues.test.ts
@@ -1,0 +1,68 @@
+import * as config from "../../../host.json";
+import { MAX_RETRIES, retryMessageEnqueue } from "../azure_queues";
+
+const aQueueService = {
+  updateMessage: jest.fn((_, __, ___, ____, cb) => {
+    cb({});
+  })
+};
+
+const aContext = {
+  bindingData: {
+    dequeueCount: 1,
+    id: "1",
+    popReceipt: "receipt"
+  },
+  bindings: {},
+  done: jest.fn(),
+  invocationId: "1",
+  log: jest.fn(),
+  warn: jest.fn()
+};
+
+const aContextWithManyRetries = {
+  bindingData: {
+    dequeueCount: 100000,
+    id: "1",
+    popReceipt: "receipt"
+  },
+  bindings: {},
+  done: jest.fn(),
+  invocationId: "1",
+  log: jest.fn(),
+  warn: jest.fn()
+};
+
+describe("azureQueues", () => {
+  it("should have MAX_RETRIES = maxDequeueCount - 1", async () => {
+    // tslint:disable-next-line:no-any
+    expect(MAX_RETRIES).toEqual((config as any).queues.maxDequeueCount - 1);
+  });
+});
+
+describe("retry", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("should call context.done() with an argument", async () => {
+    // tslint:disable-next-line:no-any
+    retryMessageEnqueue(aQueueService as any, "queueName", aContext as any);
+    expect(aQueueService.updateMessage).toHaveBeenCalledTimes(1);
+    expect(aContext.done).toHaveBeenCalledTimes(1);
+    expect(aContext.done).toHaveBeenCalledWith(expect.anything());
+  });
+
+  it("should not update the message timeout in case the maximum number of retries is reached", async () => {
+    retryMessageEnqueue(
+      // tslint:disable-next-line:no-any
+      aQueueService as any,
+      "queueName",
+      // tslint:disable-next-line:no-any
+      aContextWithManyRetries as any
+    );
+    expect(aQueueService.updateMessage).not.toHaveBeenCalled();
+    expect(aContextWithManyRetries.done).toHaveBeenCalledTimes(1);
+    expect(aContextWithManyRetries.done).toHaveBeenCalledWith(
+      expect.anything()
+    );
+  });
+});

--- a/lib/utils/azure_queues.ts
+++ b/lib/utils/azure_queues.ts
@@ -1,0 +1,111 @@
+/**
+ * Implements utility functions for Azure Storage queues
+ */
+import * as winston from "winston";
+
+import { IContext } from "azure-functions-types";
+import { QueueService } from "azure-storage";
+
+import { Option, some } from "fp-ts/lib/Option";
+
+// Any delay must be less than 7 days (< 604800 seconds)
+const MAX_BACKOFF_MS = 7 * 24 * 3600 * 1000;
+const MIN_BACKOFF_MS = 285;
+
+// MAX_RETRIES *must* equal (maxDequeueCount - 1)
+// if (MAX_RETRIES < maxDequeueCount) - 1 there will be other extraneous
+//    #(maxDequeueCount - MAX_RETRIES) retries with the default visibilityTimeout
+//    before putting the message into the poison queue
+// if (MAX_RETRIES > maxDequeueCount - 1) the system will retry even after maxDequeueCount
+//    is reached and duplicate messages will be put into the poison queue
+export const MAX_RETRIES = Math.floor(
+  Math.log2(MAX_BACKOFF_MS / MIN_BACKOFF_MS)
+);
+
+/**
+ * Compute the timeout in seconds before the message will be processed again.
+ * returns none in case the maximum number of retries is reached
+ */
+export const getDelaySecForRetries = (
+  retries: number,
+  maxRetries = MAX_RETRIES,
+  minBackoff = MIN_BACKOFF_MS
+): Option<number> =>
+  some(retries)
+    .filter(nr => nr <= maxRetries)
+    .map(nr => Math.ceil(minBackoff * Math.pow(2, nr) / 1000));
+
+export function queueMessageToString(context: IContext): string {
+  /* istanbul ignore next */
+  return [
+    "bindings = ",
+    JSON.stringify(context.bindings),
+    "; queueTrigger = ",
+    context.bindingData.queueTrigger,
+    "; expirationTime = ",
+    context.bindingData.expirationTime,
+    "; insertionTime = ",
+    context.bindingData.insertionTime,
+    "; nextVisibleTime = ",
+    context.bindingData.nextVisibleTime,
+    "; id = ",
+    context.bindingData.id,
+    "; popReceipt = ",
+    context.bindingData.popReceipt,
+    "; dequeueCount = ",
+    context.bindingData.dequeueCount
+  ].join("");
+}
+
+/**
+ * Schedule the re-processing of a message in the queue
+ * after an incremental delay (visibilityTimeout).
+ *
+ * Useful in case of transient errors. The message is enqueued with
+ * a newly computed visibilityTimeout (proportional to dequeueCount)
+ *
+ * @param queueService  The Azure storage queue service
+ * @param queueName     The Azure storage queue name
+ * @param context       The Functions context with bindings
+ */
+export function retryMessageEnqueue(
+  queueService: QueueService,
+  queueName: string,
+  context: IContext
+): void {
+  const queueMessage = context.bindingData;
+
+  winston.debug(`Retry to handle message ${queueMessageToString(context)}`);
+
+  // dequeueCount starts with one (not zero)
+  const numberOfRetries = queueMessage.dequeueCount;
+
+  getDelaySecForRetries(numberOfRetries)
+    .map(visibilityTimeoutSec => {
+      // update message visibilityTimeout
+      queueService.updateMessage(
+        queueName,
+        queueMessage.id,
+        queueMessage.popReceipt,
+        visibilityTimeoutSec,
+        err => {
+          context.done(
+            err ||
+              `Retrying with timeout|retry=${numberOfRetries}|timeout=${visibilityTimeoutSec}|queueMessageId=${
+                queueMessage.id
+              }`
+          );
+        }
+      );
+    })
+    .getOrElse(() => {
+      winston.info(
+        `Maximum number of retries reached|retries=${numberOfRetries}|${
+          queueMessage.id
+        }`
+      );
+      context.done(
+        `Moving queueMessage=${queueMessage.id} to ${queueName}-poison`
+      );
+    });
+}

--- a/lib/utils/errors.ts
+++ b/lib/utils/errors.ts
@@ -1,0 +1,37 @@
+/**
+ * Contains Error types,
+ * used to clarify the intent of a throw
+ * and useful inside unit tests.
+ */
+
+export const enum ErrorTypes {
+  TransientError = "TransientError",
+  PermanentError = "PermanentError"
+}
+
+interface IRuntimeError<T extends ErrorTypes> {
+  readonly kind: T;
+  readonly message: string;
+  readonly cause?: Error;
+}
+
+const RuntimeError = <T extends ErrorTypes>(
+  kind: T
+): ((message: string, cause?: Error) => IRuntimeError<T>) => {
+  return (message: string, cause?: Error) => ({
+    cause,
+    kind,
+    message
+  });
+};
+
+export type TransientError = IRuntimeError<ErrorTypes.TransientError>;
+export const TransientError = RuntimeError(ErrorTypes.TransientError);
+
+export type PermanentError = IRuntimeError<ErrorTypes.PermanentError>;
+export const PermanentError = RuntimeError(ErrorTypes.PermanentError);
+
+export type RuntimeError = TransientError | PermanentError;
+
+export const isTransient = (error: RuntimeError): error is TransientError =>
+  error.kind === ErrorTypes.TransientError;


### PR DESCRIPTION
Work in progress for https://www.pivotaltracker.com/story/show/150597257

We can re-schedule a message in the queue for later processing using visibilityTimeout.

Two possible retry stategies: 

1. **update** the visibilityTimeout of the received message then put it again in the queue. this strategy use the `dequeCount` property in Functions bindings and calls `context.done(err)` to return the message to the queue. after 7 days the message will be deleted from the queue in any case.

2. **create** a new message in the queue with the computed visibilityTimeout. this strategy does not rely on `dequeCount` (as it's always = 1) and calls `context.done()` to remove the old message from the queue. the number of retries is saved in the message payload.

## 1 Pros (update the same message)

- when maxDequeCount will be reached the message is moved automatically into the poison-queue
- you don't have to save the number of retries into the message payload (as dequeCount is a system property)

## 2 Pros (create a new message for every retry and delete the old one)

- you can check the number of retries looking into the message payload
- number of retries does not depened on maxDequeCount 
- you can schedule retries for more than 7 days
- context.done() does not log an error

Probably #1 is more useful if you plan to use the poison queue someway.

I chose to not use an exponential backoff strategy because the intervals between retry (in seconds) where not optimal. using a fixed number of intervals gives us more control.

see https://github.com/teamdigitale/digital-citizenship-functions/pull/133/files#diff-2d141546a695a0fa4638dedaf20abc72R9