### PR TITLE
Fix withRequestMiddlewares signatures

### DIFF
--- a/lib/utils/request_middleware.ts
+++ b/lib/utils/request_middleware.ts
@@ -60,58 +60,45 @@ export type IRequestMiddleware<R, T> = (
 // and each parameter must be of the same type returned by the corresponding middleware.
 //
 
-export function withRequestMiddlewares<RH, R1, T1>(
+export function withRequestMiddlewares<R1, T1>(
   v1: IRequestMiddleware<R1, T1>
-): (handler: (v1: T1) => Promise<IResponse<RH>>) => RequestHandler<RH | R1>;
+): <RH>(handler: (v1: T1) => Promise<IResponse<RH>>) => RequestHandler<RH | R1>;
 
-export function withRequestMiddlewares<RH, R1, R2, T1, T2>(
+export function withRequestMiddlewares<R1, R2, T1, T2>(
   v1: IRequestMiddleware<R1, T1>,
   v2: IRequestMiddleware<R2, T2>
-): (
+): <RH>(
   handler: (v1: T1, v2: T2) => Promise<IResponse<RH>>
 ) => RequestHandler<RH | R1 | R2>;
 
-export function withRequestMiddlewares<RH, R1, R2, R3, T1, T2, T3>(
+export function withRequestMiddlewares<R1, R2, R3, T1, T2, T3>(
   v1: IRequestMiddleware<R1, T1>,
   v2: IRequestMiddleware<R2, T2>,
   v3: IRequestMiddleware<R3, T3>
-): (
+): <RH>(
   handler: (v1: T1, v2: T2, v3: T3) => Promise<IResponse<RH>>
 ) => RequestHandler<RH | R1 | R2 | R3>;
 
-export function withRequestMiddlewares<RH, R1, R2, R3, R4, T1, T2, T3, T4>(
+export function withRequestMiddlewares<R1, R2, R3, R4, T1, T2, T3, T4>(
   v1: IRequestMiddleware<R1, T1>,
   v2: IRequestMiddleware<R2, T2>,
   v3: IRequestMiddleware<R3, T3>,
   v4: IRequestMiddleware<R4, T4>
-): (
+): <RH>(
   handler: (v1: T1, v2: T2, v3: T3, v4: T4) => Promise<IResponse<RH>>
 ) => RequestHandler<RH | R1 | R2 | R3 | R4>;
 
-export function withRequestMiddlewares<
-  RH,
-  R1,
-  R2,
-  R3,
-  R4,
-  R5,
-  T1,
-  T2,
-  T3,
-  T4,
-  T5
->(
+export function withRequestMiddlewares<R1, R2, R3, R4, R5, T1, T2, T3, T4, T5>(
   v1: IRequestMiddleware<R1, T1>,
   v2: IRequestMiddleware<R2, T2>,
   v3: IRequestMiddleware<R3, T3>,
   v4: IRequestMiddleware<R4, T4>,
   v5: IRequestMiddleware<R5, T5>
-): (
+): <RH>(
   handler: (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5) => Promise<IResponse<RH>>
 ) => RequestHandler<RH | R1 | R2 | R3 | R4 | R5>;
 
 export function withRequestMiddlewares<
-  RH,
   R1,
   R2,
   R3,
@@ -131,7 +118,7 @@ export function withRequestMiddlewares<
   v4: IRequestMiddleware<R4, T4>,
   v5: IRequestMiddleware<R5, T5>,
   v6: IRequestMiddleware<R6, T6>
-): (
+): <RH>(
   handler: (
     v1: T1,
     v2: T2,
@@ -154,7 +141,6 @@ export function withRequestMiddlewares<
  * That final response gets sent to the client.
  */
 export function withRequestMiddlewares<
-  RH,
   R1,
   R2,
   R3,
@@ -174,7 +160,7 @@ export function withRequestMiddlewares<
   v4?: IRequestMiddleware<R4, T4>,
   v5?: IRequestMiddleware<R5, T5>,
   v6?: IRequestMiddleware<R6, T6>
-): (
+): <RH>(
   handler: (
     v1: T1,
     v2?: T2,
@@ -184,7 +170,16 @@ export function withRequestMiddlewares<
     v6?: T6
   ) => Promise<IResponse<RH>>
 ) => RequestHandler<R1 | R2 | R3 | R4 | R5 | R6 | RH> {
-  return handler => {
+  return <RH>(
+    handler: (
+      v1: T1,
+      v2?: T2,
+      v3?: T3,
+      v4?: T4,
+      v5?: T5,
+      v6?: T6
+    ) => Promise<IResponse<RH>>
+  ) => {
     // The outer promise with resolve to a type that can either be the the type returned
     // by the handler or one of the types returned by any of the middlewares (i.e., when
     // a middleware returns an error response).


### PR DESCRIPTION
@cloudify I was reading your [post](http://federicoferoldi.com/2017/12/28/using-the-typescript-type-system-to-validate-express-handlers.html) and noticed a possible issue: I think that the type parameter `RH` should be moved to the right

```ts
// current signature
declare function withRequestMiddlewares<RH, R1, R2, T1, T2>(
  m1: IRequestMiddleware<R1, T1>,
  m2: IRequestMiddleware<R2, T2>
): (handler: (v1: T1, v2: T2) => Promise<IResponse<RH>>) => RequestHandler<RH | R1 | R2>

declare const m1: IRequestMiddleware<'R1', 'T1'>
declare const m2: IRequestMiddleware<'R2', 'T2'>
declare const handler: (v1: 'T1', v2: 'T2') => Promise<IResponse<'RH'>>

// const x: (req: Request) => Promise<IResponse<{} | "R1" | "R2">>
const x = withRequestMiddlewares(m1, m2)(handler)
```

Note the inferred type `{}` for `RH`

```ts
// proposed signature
declare function withRequestMiddlewares2<R1, R2, T1, T2>(
  m1: IRequestMiddleware<R1, T1>,
  m2: IRequestMiddleware<R2, T2>
): <RH>(handler: (v1: T1, v2: T2) => Promise<IResponse<RH>>) => RequestHandler<RH | R1 | R2>

// const y: (req: Request) => Promise<IResponse<"R1" | "R2" | "RH">>
const y = withRequestMiddlewares2(m1, m2)(handler)
```