### PR TITLE
Add schema to api Swagger definitions for profile update

### DIFF
--- a/api/public_api_v1.yaml
+++ b/api/public_api_v1.yaml
@@ -173,8 +173,12 @@ paths:
               version: 0
         '400':
           description: Invalid payload.
+          schema:
+            $ref: "#/definitions/ProblemJson"
         '500':
           description: Profile cannot be updated.
+          schema:
+            $ref: "#/definitions/ProblemJson"
       description: Create or update the preferences for the user identified by the
         provided fiscal code.
       operationId: upsertProfile


### PR DESCRIPTION
Error responses in profile update definitions lacks of schema. Without the schema the autorest utility fails to create a correct api client