### PR TITLE
refactor: enum types

### DIFF
--- a/lib/utils/types.ts
+++ b/lib/utils/types.ts
@@ -1,4 +1,3 @@
-// tslint:disable:no-any
 import * as t from "io-ts";
 
 import { Set as SerializableSet } from "json-set-map";
@@ -12,27 +11,21 @@ export type Tagged<T, S extends t.mixed, A> = t.Type<A & T, S>;
  * Tags an io-ts type with an interface T
  */
 export const tag = <T>() => <S, A>(type: t.Type<A, S>): Tagged<T, S, A> =>
+  // tslint:disable-next-line:no-any
   type as any;
-
-const getObjectValues = <T extends object>(obj: T): ReadonlyArray<string> =>
-  Object.keys(obj).reduce<ReadonlyArray<string>>(
-    (acc, key) => [...acc, (obj as any)[key]],
-    []
-  );
 
 /**
  * Creates an io-ts Type from an enum
  */
-export const enumType = <E>(e: {}, name: string): t.Type<any, E> => {
-  const values = getObjectValues(e);
-  const isE: (v: any) => boolean = v =>
-    typeof v === "string" && values.indexOf(v) >= 0;
-  return new t.Type<any, E>(
-    name,
-    (v): v is E => isE(v),
-    (v, c) => (isE(v) ? t.success(v) : t.failure(v, c)),
-    t.identity
+export const enumType = <E>(e: object, name: string): t.Type<E> => {
+  // get object values as keys
+  const keys = Object.keys(e).reduce(
+    // tslint:disable-next-line:no-any
+    (o, k) => ({ ...o, [(e as any)[k]]: undefined }),
+    {} as { readonly [k: string]: undefined }
   );
+  // tslint:disable-next-line:no-any
+  return t.keyof(keys, name) as any;
 };
 
 /**

--- a/lib/utils/types.ts
+++ b/lib/utils/types.ts
@@ -15,18 +15,22 @@ export const tag = <T>() => <S, A>(type: t.Type<A, S>): Tagged<T, S, A> =>
   type as any;
 
 /**
- * Creates an io-ts Type from an enum
+ * Returns an object where the keys are the values
+ * of the object passed as input and all values are undefined
  */
-export const enumType = <E>(e: object, name: string): t.Type<E> => {
-  // get object values as keys
-  const keys = Object.keys(e).reduce(
+const getObjectValues = (e: object) =>
+  Object.keys(e).reduce(
     // tslint:disable-next-line:no-any
     (o, k) => ({ ...o, [(e as any)[k]]: undefined }),
     {} as { readonly [k: string]: undefined }
   );
+
+/**
+ * Creates an io-ts Type from an enum
+ */
+export const enumType = <E>(e: object, name: string): t.Type<E> =>
   // tslint:disable-next-line:no-any
-  return t.keyof(keys, name) as any;
-};
+  t.keyof(getObjectValues(e), name) as any;
 
 /**
  * Creates an io-ts Type from a ReadonlySet


### PR DESCRIPTION
this is a better enum type than the actual one, as this one is statically checked
while actually you can create objects with a wrong enum key and it only fails at runtime

ref. https://github.com/gcanti/io-ts/issues/67#issuecomment-368068197