### PR TITLE
[#150588117] WIP added time to live check to email notification handler

### DIFF
--- a/api/definitions.yaml
+++ b/api/definitions.yaml
@@ -69,7 +69,7 @@ NewMessage:
   type: object
   properties:
     time_to_live:
-      $ref: "#/TimeToLive"
+      $ref: "#/TimeToLiveSeconds"
     content:
       $ref: "#/MessageContent"
     default_addresses:
@@ -98,7 +98,7 @@ CreatedMessageWithContent:
     fiscal_code:
       $ref: "#/FiscalCode"
     time_to_live:
-      $ref: "#/TimeToLive"
+      $ref: "#/TimeToLiveSeconds"
     content:
       $ref: "#/MessageContent"
     sender_service_id:
@@ -114,7 +114,7 @@ CreatedMessageWithoutContent:
     fiscal_code:
       $ref: "#/FiscalCode"
     time_to_live:
-      $ref: "#/TimeToLive"
+      $ref: "#/TimeToLiveSeconds"
     sender_service_id:
       type: string
   required:
@@ -211,11 +211,11 @@ IsInboxEnabled:
   default: false
   description: True if the recipient of a message wants to store its content for
     later retrieval.
-TimeToLive:
+TimeToLiveSeconds:
   type: integer
   default: 3600
   minimum: 3600
-  maximum: 31536000
+  maximum: 604800
   description: This parameter specifies for how long (in seconds) the system will
     try to deliver the message to the channels configured by the user.
   example: 3600

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,12 +110,7 @@ gulp.task("unit:test", () => {
       // for some unknow reason jest tests won't exit on win32 machine
       // when run through gulp (running the tests directly through the jest CLI just works)
       // that's the reason of the `forceExit` flag
-      .pipe(
-        run(
-          "jest --coverage --runInBand" +
-            (process.platform === "win32" ? " --forceExit" : "")
-        )
-      )
+      .pipe(run("jest --coverage --runInBand"))
   );
 });
 

--- a/lib/__tests__/created_message_queue_handler.test.ts
+++ b/lib/__tests__/created_message_queue_handler.test.ts
@@ -12,14 +12,6 @@ process.env.MESSAGE_CONTAINER_NAME = "anyMessageContainerName";
 // tslint:disable-next-line:no-object-mutation
 process.env.QueueStorageConnection = "anyQueueStorageConnection";
 
-import {
-  handleMessage,
-  index,
-  MESSAGE_QUEUE_NAME,
-  processRuntimeError,
-  processSuccess
-} from "../created_message_queue_handler";
-
 import { CreatedMessageEvent } from "../models/created_message_event";
 import { NewMessageWithContent } from "../models/message";
 
@@ -48,8 +40,23 @@ import { TimeToLiveSeconds } from "../api/definitions/TimeToLiveSeconds";
 import { NotificationEvent } from "../models/notification_event";
 
 jest.mock("azure-storage");
+
+jest.mock("../models/notification_status", () => ({
+  NOTIFICATION_STATUS_COLLECTION_NAME: "foobar",
+  NotificationStatusModel: jest.fn(),
+  getNotificationStatusUpdater: () => (x: any) => Promise.resolve(x)
+}));
+
 jest.mock("../utils/azure_queues");
 import { updateMessageVisibilityTimeout } from "../utils/azure_queues";
+
+import {
+  handleMessage,
+  index,
+  MESSAGE_QUEUE_NAME,
+  processRuntimeError,
+  processSuccess
+} from "../created_message_queue_handler";
 
 afterEach(() => {
   jest.resetAllMocks();
@@ -677,7 +684,8 @@ describe("processSuccess", () => {
   it("should enqueue notification to the email queue if an email is present", async () => {
     const notification = aCreatedNotificationWithEmail;
 
-    const result = processSuccess(
+    const result = await processSuccess(
+      {} as any,
       notification as any,
       aMessage,
       aMessageEvent.senderMetadata

--- a/lib/__tests__/created_message_queue_handler.test.ts
+++ b/lib/__tests__/created_message_queue_handler.test.ts
@@ -44,7 +44,7 @@ import { EmailString, NonEmptyString } from "../utils/strings";
 jest.mock("azure-storage");
 jest.mock("../utils/azure_queues");
 import { NotificationChannelEnum } from "../api/definitions/NotificationChannel";
-import { TimeToLive } from "../api/definitions/TimeToLive";
+import { TimeToLiveSeconds } from "../api/definitions/TimeToLiveSeconds";
 import { NotificationEvent } from "../models/notification_event";
 import { updateMessageVisibilityTimeout } from "../utils/azure_queues";
 
@@ -81,7 +81,7 @@ const aMessage: NewMessageWithContent = {
   kind: "INewMessageWithContent",
   senderServiceId: "",
   senderUserId: "u123" as NonEmptyString,
-  timeToLive: 3600 as TimeToLive
+  timeToLiveSeconds: 3600 as TimeToLiveSeconds
 };
 
 const aMessageEvent: CreatedMessageEvent = {

--- a/lib/__tests__/created_message_queue_handler.test.ts
+++ b/lib/__tests__/created_message_queue_handler.test.ts
@@ -1,5 +1,4 @@
 // tslint:disable:no-any
-import { MessageContent } from "../api/definitions/MessageContent";
 
 // set a dummy value for the env vars needed by the handler
 // tslint:disable-next-line:no-object-mutation
@@ -17,14 +16,15 @@ import {
   handleMessage,
   index,
   MESSAGE_QUEUE_NAME,
-  processResolve
+  processRuntimeError,
+  processSuccess
 } from "../created_message_queue_handler";
 import { CreatedMessageEvent } from "../models/created_message_event";
-import { NewMessageWithoutContent } from "../models/message";
+import { NewMessageWithContent } from "../models/message";
 
 import * as functionConfig from "../../CreatedMessageQueueHandler/function.json";
 
-import { none, some } from "fp-ts/lib/Option";
+import { isSome, none, some } from "fp-ts/lib/Option";
 import { FiscalCode } from "../api/definitions/FiscalCode";
 import { MessageBodyMarkdown } from "../api/definitions/MessageBodyMarkdown";
 
@@ -44,8 +44,9 @@ import { EmailString, NonEmptyString } from "../utils/strings";
 jest.mock("azure-storage");
 jest.mock("../utils/azure_queues");
 import { NotificationChannelEnum } from "../api/definitions/NotificationChannel";
+import { TimeToLive } from "../api/definitions/TimeToLive";
 import { NotificationEvent } from "../models/notification_event";
-import { retryMessageEnqueue } from "../utils/azure_queues";
+import { updateMessageVisibilityTimeout } from "../utils/azure_queues";
 
 afterEach(() => {
   jest.resetAllMocks();
@@ -68,21 +69,23 @@ const anEmailNotification: EmailNotification = {
   messageId: "m123" as NonEmptyString
 };
 
-const aMessage: NewMessageWithoutContent = {
+const aMessageBodyMarkdown = "test".repeat(80) as MessageBodyMarkdown;
+
+const aMessage: NewMessageWithContent = {
+  content: {
+    markdown: aMessageBodyMarkdown
+  },
+  createdAt: new Date(),
   fiscalCode: aWrongFiscalCode,
   id: "xyz" as NonEmptyString,
-  kind: "INewMessageWithoutContent",
+  kind: "INewMessageWithContent",
   senderServiceId: "",
-  senderUserId: "u123" as NonEmptyString
+  senderUserId: "u123" as NonEmptyString,
+  timeToLive: 3600 as TimeToLive
 };
-
-const aMessageBodyMarkdown = "test".repeat(80) as MessageBodyMarkdown;
 
 const aMessageEvent: CreatedMessageEvent = {
   message: aMessage,
-  messageContent: {
-    markdown: aMessageBodyMarkdown
-  },
   senderMetadata: {
     departmentName: "IT" as NonEmptyString,
     organizationName: "agid" as NonEmptyString,
@@ -123,8 +126,11 @@ const aCreatedNotificationWithEmail: NewNotification = {
 };
 
 const anEmailNotificationEvent: NotificationEvent = {
-  messageContent: aMessageEvent.messageContent,
-  messageId: aCreatedNotificationWithEmail.messageId,
+  message: {
+    ...aMessage,
+    content: { markdown: aMessageBodyMarkdown },
+    kind: "INewMessageWithContent"
+  },
   notificationId: aCreatedNotificationWithEmail.id,
   senderMetadata: aMessageEvent.senderMetadata
 };
@@ -202,7 +208,6 @@ describe("handleMessage", () => {
       {} as any,
       {} as any,
       retrievedMessageMock as any,
-      {} as any,
       none
     );
     expect(profileModelMock.findOneProfileByFiscalCode).toHaveBeenCalledWith(
@@ -231,7 +236,6 @@ describe("handleMessage", () => {
       {} as any,
       {} as any,
       retrievedMessageMock as any,
-      {} as any,
       none
     );
 
@@ -270,7 +274,6 @@ describe("handleMessage", () => {
         notificationModelMock as any,
         {} as any,
         retrievedMessageMock as any,
-        {} as any,
         none
       );
 
@@ -310,7 +313,6 @@ describe("handleMessage", () => {
         notificationModelMock as any,
         {} as any,
         retrievedMessageMock as any,
-        {} as any,
         none
       );
 
@@ -367,7 +369,6 @@ describe("handleMessage", () => {
         notificationModelMock as any,
         {} as any,
         retrievedMessageMock as any,
-        {} as any,
         some({
           email: anEmail
         })
@@ -419,7 +420,6 @@ describe("handleMessage", () => {
         notificationModelMock as any,
         {} as any,
         retrievedMessageMock as any,
-        {} as any,
         some({
           email: anEmail
         })
@@ -476,17 +476,12 @@ describe("handleMessage", () => {
       })
     };
 
-    const messageContent: MessageContent = {
-      markdown: aMessageBodyMarkdown
-    };
-
     const response = await handleMessage(
       profileModelMock as any,
       messageModelMock as any,
       notificationModelMock as any,
       aBlobService as any,
       retrievedMessageMock as any,
-      messageContent,
       some({
         email: anEmail
       })
@@ -553,17 +548,12 @@ describe("handleMessage", () => {
       })
     };
 
-    const messageContent: MessageContent = {
-      markdown: aMessageBodyMarkdown
-    };
-
     const response = await handleMessage(
       profileModelMock as any,
       messageModelMock as any,
       notificationModelMock as any,
       aBlobService as any,
       retrievedMessageMock as any,
-      messageContent,
       some({
         email: anEmail
       })
@@ -613,7 +603,6 @@ describe("handleMessage", () => {
       notificationModelMock as any,
       {} as any,
       retrievedMessageMock as any,
-      {} as any,
       none
     );
 
@@ -627,84 +616,43 @@ describe("handleMessage", () => {
   });
 });
 
-describe("processResolve", () => {
+describe("processSuccess", () => {
   it("should enqueue notification to the email queue if an email is present", async () => {
-    const errorOrNotification = right(aCreatedNotificationWithEmail);
+    const notification = aCreatedNotificationWithEmail;
 
-    const contextMock = {
-      bindings: {},
-      done: jest.fn()
-    };
-
-    processResolve(
-      errorOrNotification as any,
-      contextMock as any,
-      aMessageEvent.messageContent,
+    const result = processSuccess(
+      notification as any,
+      aMessage,
       aMessageEvent.senderMetadata
     );
 
-    expect(contextMock.done).toHaveBeenCalledTimes(1);
-    expect(contextMock.done).toHaveBeenCalledWith(undefined, {
-      emailNotification: anEmailNotificationEvent
-    });
+    expect(isRight(result)).toBeTruthy();
+    if (isRight(result)) {
+      expect(isSome(result.value)).toBeTruthy();
+      if (isSome(result.value)) {
+        expect(result.value.value).toEqual({
+          emailNotification: anEmailNotificationEvent
+        });
+      }
+    }
   });
+});
 
+describe("processRuntimeError", () => {
   it("should retry on transient error", async () => {
-    const errorOrNotification = left(TransientError("err"));
-
-    const contextMock = {
-      bindings: {
-        emailNotification: undefined
-      },
-      done: jest.fn(),
-      log: jest.fn()
-    };
-
-    const retrievedMessageMock = {
-      fiscalCode: aWrongFiscalCode
-    };
-
-    const spy = jest.spyOn(winston, "error");
-
-    processResolve(
-      errorOrNotification as any,
-      contextMock as any,
-      retrievedMessageMock as any,
-      {} as any
-    );
-
-    expect(retryMessageEnqueue).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(contextMock.bindings.emailNotification).toEqual(undefined);
+    const error = TransientError("err");
+    const winstonSpy = jest.spyOn(winston, "warn");
+    await processRuntimeError(error as any, {} as any);
+    expect(updateMessageVisibilityTimeout).toHaveBeenCalledTimes(1);
+    expect(winstonSpy).toHaveBeenCalledTimes(1);
   });
+
   it("should fail in case of permament error", async () => {
-    const errorOrNotification = left(PermanentError("err"));
-
-    const contextMock = {
-      bindings: {
-        emailNotification: undefined
-      },
-      done: jest.fn(),
-      log: jest.fn()
-    };
-
-    const retrievedMessageMock = {
-      fiscalCode: aWrongFiscalCode
-    };
-
-    const spy = jest.spyOn(winston, "error");
-
-    processResolve(
-      errorOrNotification as any,
-      contextMock as any,
-      retrievedMessageMock as any,
-      {} as any
-    );
-
-    expect(retryMessageEnqueue).not.toHaveBeenCalled();
-    expect(contextMock.done).toHaveBeenCalledWith();
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(contextMock.bindings.emailNotification).toEqual(undefined);
+    const error = PermanentError("err");
+    const winstonSpy = jest.spyOn(winston, "error");
+    await processRuntimeError(error as any, {} as any);
+    expect(updateMessageVisibilityTimeout).not.toHaveBeenCalled();
+    expect(winstonSpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/lib/__tests__/emailnotifications_queue_handler.test.ts
+++ b/lib/__tests__/emailnotifications_queue_handler.test.ts
@@ -37,11 +37,8 @@ import {
   generateDocumentHtml,
   handleNotification,
   index,
-  processResolve,
   sendMail
 } from "../emailnotifications_queue_handler";
-
-import { retryMessageEnqueue } from "../utils/azure_queues";
 
 import { MessageBodyMarkdown } from "../api/definitions/MessageBodyMarkdown";
 import { MessageSubject } from "../api/definitions/MessageSubject";
@@ -51,19 +48,22 @@ import {
   NotificationAddressSourceEnum,
   NotificationModel
 } from "../models/notification";
-import { isTransient, PermanentError, TransientError } from "../utils/errors";
+import { isTransient } from "../utils/errors";
 
 import { NotificationEvent } from "../models/notification_event";
 
 import * as functionConfig from "../../EmailNotificationsQueueHandler/function.json";
+import { MessageContent } from "../api/definitions/MessageContent";
 import { NotificationChannelEnum } from "../api/definitions/NotificationChannel";
 import { NotificationChannelStatusValueEnum } from "../api/definitions/NotificationChannelStatusValue";
+import { TimeToLive } from "../api/definitions/TimeToLive";
 import {
   makeStatusId,
   NotificationStatusModel,
   RetrievedNotificationStatus
 } from "../models/notification_status";
 import { NonNegativeNumber } from "../utils/numbers";
+import { readableReport } from "../utils/validation_reporters";
 
 // jest.mock("../models/notification");
 
@@ -78,18 +78,60 @@ function flushPromises(): Promise<void> {
 
 const aFiscalCode = "FRLFRC74E04B157I" as FiscalCode;
 
-const aNotificationEvent: NotificationEvent = {
-  messageContent: {
-    markdown: "test".repeat(80) as MessageBodyMarkdown,
-    subject: "t".repeat(30) as MessageSubject
+const aMessageId = "A_MESSAGE_ID" as NonEmptyString;
+
+const aMessage = {
+  createdAt: new Date().toISOString(),
+  fiscalCode: aFiscalCode,
+  id: aMessageId,
+  kind: "INewMessageWithoutContent",
+  senderServiceId: "",
+  senderUserId: "u123" as NonEmptyString,
+  timeToLive: 3600 as TimeToLive
+};
+
+const aMessageBodyMarkdown = "test".repeat(80) as MessageBodyMarkdown;
+const aMessageBodySubject = "t".repeat(30) as MessageSubject;
+
+const aNotificationId = "A_NOTIFICATION_ID" as NonEmptyString;
+
+const aSenderMetadata: CreatedMessageEventSenderMetadata = {
+  departmentName: "dept" as NonEmptyString,
+  organizationName: "org" as NonEmptyString,
+  serviceName: "service" as NonEmptyString
+};
+
+const aNotificationEvent = {
+  message: {
+    ...aMessage,
+    content: {
+      markdown: aMessageBodyMarkdown,
+      subject: aMessageBodySubject
+    },
+    kind: "INewMessageWithContent"
   },
-  messageId: "A_MESSAGE_ID" as NonEmptyString,
-  notificationId: "A_NOTIFICATION_ID" as NonEmptyString,
-  senderMetadata: {
-    departmentName: "dept" as NonEmptyString,
-    organizationName: "org" as NonEmptyString,
-    serviceName: "service" as NonEmptyString
+  notificationId: aNotificationId,
+  senderMetadata: aSenderMetadata
+};
+
+const getMockNotificationEvent = (
+  messageContent: MessageContent = {
+    markdown: aMessageBodyMarkdown,
+    subject: aMessageBodySubject
   }
+) => {
+  return NotificationEvent.decode(
+    Object.assign({}, aNotificationEvent, {
+      message: {
+        ...aNotificationEvent.message,
+        content: messageContent
+      }
+    })
+  ).getOrElseL(errs => {
+    throw new Error(
+      "Cannot deserialize NotificationEvent: " + readableReport(errs)
+    );
+  });
 };
 
 const aNotification: Notification = {
@@ -100,13 +142,7 @@ const aNotification: Notification = {
     }
   },
   fiscalCode: aFiscalCode,
-  messageId: "A_MESSAGE_ID" as NonEmptyString
-};
-
-const aSenderMetadata: CreatedMessageEventSenderMetadata = {
-  departmentName: "IT" as NonEmptyString,
-  organizationName: "agid" as NonEmptyString,
-  serviceName: "Test" as NonEmptyString
+  messageId: aMessageId
 };
 
 const aRetrievedNotificationStatus: RetrievedNotificationStatus = {
@@ -115,22 +151,19 @@ const aRetrievedNotificationStatus: RetrievedNotificationStatus = {
   channel: NotificationChannelEnum.EMAIL,
   id: "1" as NonEmptyString,
   kind: "IRetrievedNotificationStatus",
-  messageId: "A_MESSAGE_ID" as NonEmptyString,
-  notificationId: "A_NOTIFICATION_ID" as NonEmptyString,
+  messageId: aMessageId,
+  notificationId: aNotificationId,
   status: NotificationChannelStatusValueEnum.SENT_TO_CHANNEL,
-  statusId: makeStatusId(
-    "A_NOTIFICATION_ID" as NonEmptyString,
-    NotificationChannelEnum.EMAIL
-  ),
+  statusId: makeStatusId(aNotificationId, NotificationChannelEnum.EMAIL),
   updateAt: new Date(),
   version: 1 as NonNegativeNumber
 };
 
-function getUpdateNotificationStatusMock(
-  retrievedNotificationStatus: any = right(some(aRetrievedNotificationStatus))
-): any {
-  return jest.fn(() => Promise.resolve(retrievedNotificationStatus));
-}
+// function getUpdateNotificationStatusMock(
+//   retrievedNotificationStatus: any = right(aRetrievedNotificationStatus)
+// ): any {
+//   return jest.fn(() => Promise.resolve(retrievedNotificationStatus));
+// }
 
 describe("sendMail", () => {
   it("should call sendMail on the Transporter and return the result", async () => {
@@ -177,13 +210,12 @@ describe("handleNotification", () => {
       {} as any,
       {} as any,
       notificationModelMock as any,
-      getUpdateNotificationStatusMock(),
-      aNotificationEvent
+      getMockNotificationEvent()
     );
 
     expect(notificationModelMock.find).toHaveBeenCalledWith(
-      "A_NOTIFICATION_ID",
-      "A_MESSAGE_ID"
+      aNotificationId,
+      aMessageId
     );
     expect(isLeft(result)).toBeTruthy();
     if (isLeft(result)) {
@@ -200,8 +232,7 @@ describe("handleNotification", () => {
       {} as any,
       {} as any,
       notificationModelMock as any,
-      getUpdateNotificationStatusMock(),
-      aNotificationEvent
+      getMockNotificationEvent()
     );
 
     expect(isLeft(result)).toBeTruthy();
@@ -219,8 +250,7 @@ describe("handleNotification", () => {
       {} as any,
       {} as any,
       notificationModelMock as any,
-      getUpdateNotificationStatusMock(),
-      aNotificationEvent
+      getMockNotificationEvent()
     );
 
     expect(isLeft(result)).toBeTruthy();
@@ -238,7 +268,9 @@ describe("handleNotification", () => {
     const mockTransporter = NodeMailer.createTransport(mockTransport);
 
     const aMessageContent = {
-      markdown: "# Hello world!" as MessageBodyMarkdown
+      markdown: `# Hello world!
+        lorem ipsum
+      `.repeat(10) as MessageBodyMarkdown
     };
 
     const notificationModelMock = {
@@ -246,32 +278,24 @@ describe("handleNotification", () => {
       update: jest.fn(() => Promise.resolve(right(some(aNotification))))
     };
 
-    const notificationStatusModelMock = getUpdateNotificationStatusMock();
     const result = await handleNotification(
       mockTransporter,
       mockAppinsights as any,
       notificationModelMock as any,
-      notificationStatusModelMock,
-      {
-        ...aNotificationEvent,
-        messageContent: aMessageContent,
-        senderMetadata: aSenderMetadata
-      }
+      getMockNotificationEvent(aMessageContent)
     );
 
     expect(mockTransport.sentMail.length).toBe(1);
     const sentMail = mockTransport.sentMail[0];
     expect(sentMail.data.from).toBe("no-reply@italia.it");
     expect(sentMail.data.to).toBe("pinco@pallino.com");
-    expect(sentMail.data.messageId).toBe("A_MESSAGE_ID");
+    expect(sentMail.data.messageId).toBe(aMessageId);
     expect(sentMail.data.subject).not.toBeUndefined();
     expect(sentMail.data.headers).not.toBeUndefined();
     if (sentMail.data.headers) {
       const headers = sentMail.data.headers as any;
-      expect(headers["X-Italia-Messages-MessageId"]).toBe("A_MESSAGE_ID");
-      expect(headers["X-Italia-Messages-NotificationId"]).toBe(
-        "A_NOTIFICATION_ID"
-      );
+      expect(headers["X-Italia-Messages-MessageId"]).toBe(aMessageId);
+      expect(headers["X-Italia-Messages-NotificationId"]).toBe(aNotificationId);
     }
     const emailBody = String(sentMail.data.html);
     expect(emailBody.indexOf("<h1>Hello world!</h1>")).toBeGreaterThan(0);
@@ -287,17 +311,12 @@ describe("handleNotification", () => {
       name: "notification.email.delivery",
       properties: {
         addressSource: NotificationAddressSourceEnum.DEFAULT_ADDRESS,
-        messageId: "A_MESSAGE_ID",
-        notificationId: "A_NOTIFICATION_ID",
+        messageId: aMessageId,
+        notificationId: aNotificationId,
         success: "true",
         transport: "sendgrid"
       }
     });
-
-    expect(notificationStatusModelMock).toHaveBeenCalledTimes(1);
-    expect(notificationStatusModelMock).toHaveBeenCalledWith(
-      NotificationChannelStatusValueEnum.SENT_TO_CHANNEL
-    );
 
     expect(isRight(result)).toBeTruthy();
     expect(result.value).toBeDefined();
@@ -316,6 +335,9 @@ describe("handleNotification", () => {
 # Hello world!
 
 This is a *message* from the future!
+This is a *message* from the future!
+This is a *message* from the future!
+This is a *message* from the future!
 ` as MessageBodyMarkdown
     };
 
@@ -328,24 +350,22 @@ This is a *message* from the future!
       mockTransporter,
       mockAppinsights as any,
       notificationModelMock as any,
-      getUpdateNotificationStatusMock(),
-      {
-        ...aNotificationEvent,
-        messageContent: aMessageContent,
-        senderMetadata: aSenderMetadata
-      }
+      getMockNotificationEvent(aMessageContent)
     );
 
     expect(
       String(mockTransport.sentMail[0].data.text).replace(/[ \n]+/g, "|")
     ).toBe(
-      `agid
-IT
-Test
+      `org
+dept
+service
 
 A new notification for you.
 
 HELLO WORLD!
+This is a message from the future!
+This is a message from the future!
+This is a message from the future!
 This is a message from the future!`.replace(/[ \n]+/g, "|")
     );
 
@@ -361,10 +381,6 @@ This is a message from the future!`.replace(/[ \n]+/g, "|")
     const mockTransport = MockTransport();
     const mockTransporter = NodeMailer.createTransport(mockTransport);
 
-    const aMessageContent = {
-      markdown: "# Hello world!" as MessageBodyMarkdown
-    };
-
     const notificationModelMock = {
       find: jest.fn(() => right(some(aNotification))),
       update: jest.fn(() => right(some(aNotification)))
@@ -374,8 +390,10 @@ This is a message from the future!`.replace(/[ \n]+/g, "|")
       mockTransporter,
       mockAppinsights as any,
       notificationModelMock as any,
-      getUpdateNotificationStatusMock(),
-      { ...aNotificationEvent, messageContent: aMessageContent }
+      getMockNotificationEvent({
+        markdown: aMessageBodyMarkdown,
+        subject: undefined
+      })
     );
 
     expect(mockTransport.sentMail[0].data.subject).toBe(
@@ -394,9 +412,11 @@ This is a message from the future!`.replace(/[ \n]+/g, "|")
     const mockTransport = MockTransport();
     const mockTransporter = NodeMailer.createTransport(mockTransport);
 
+    const customSubject = "A custom subject" as MessageSubject;
+
     const aMessageContent = {
-      markdown: "# Hello world!" as MessageBodyMarkdown,
-      subject: "A custom subject" as MessageSubject
+      markdown: aMessageBodyMarkdown,
+      subject: customSubject
     };
 
     const notificationModelMock = {
@@ -408,11 +428,10 @@ This is a message from the future!`.replace(/[ \n]+/g, "|")
       mockTransporter,
       mockAppinsights as any,
       notificationModelMock as any,
-      getUpdateNotificationStatusMock(),
-      { ...aNotificationEvent, messageContent: aMessageContent }
+      getMockNotificationEvent(aMessageContent)
     );
 
-    expect(mockTransport.sentMail[0].data.subject).toBe("A custom subject");
+    expect(mockTransport.sentMail[0].data.subject).toBe(customSubject);
 
     expect(isRight(result)).toBeTruthy();
     expect(result.value).toBeDefined();
@@ -428,10 +447,6 @@ This is a message from the future!`.replace(/[ \n]+/g, "|")
     };
     const mockTransporter = NodeMailer.createTransport(mockTransport as any);
 
-    const aMessageContent = {
-      markdown: "# Hello world!" as MessageBodyMarkdown
-    };
-
     const notificationModelMock = {
       find: jest.fn(() => right(some(aNotification))),
       update: jest.fn(() => right(some(aNotification)))
@@ -441,16 +456,15 @@ This is a message from the future!`.replace(/[ \n]+/g, "|")
       mockTransporter,
       mockAppinsights as any,
       notificationModelMock as any,
-      getUpdateNotificationStatusMock(),
-      { ...aNotificationEvent, messageContent: aMessageContent }
+      getMockNotificationEvent()
     );
 
     expect(mockAppinsights.trackEvent).toHaveBeenCalledWith({
       name: "notification.email.delivery",
       properties: {
         addressSource: NotificationAddressSourceEnum.DEFAULT_ADDRESS,
-        messageId: "A_MESSAGE_ID",
-        notificationId: "A_NOTIFICATION_ID",
+        messageId: aMessageId,
+        notificationId: aNotificationId,
         success: "false",
         transport: "sendgrid"
       }
@@ -463,83 +477,8 @@ This is a message from the future!`.replace(/[ \n]+/g, "|")
       expect(isTransient(result.value)).toBeTruthy();
     }
   });
-
-  it("should respond with a transient error when notification status update fails", async () => {
-    const mockAppinsights = {
-      trackEvent: jest.fn()
-    };
-
-    const mockTransport = MockTransport();
-    const mockTransporter = NodeMailer.createTransport(mockTransport);
-
-    const aMessageContent = {
-      markdown: "# Hello world!" as MessageBodyMarkdown
-    };
-
-    const notificationModelMock = {
-      find: jest.fn(() => right(some(aNotification)))
-    };
-
-    const notificationStatusModelMock = getUpdateNotificationStatusMock(
-      left(none)
-    );
-    const result = await handleNotification(
-      mockTransporter,
-      mockAppinsights as any,
-      notificationModelMock as any,
-      notificationStatusModelMock,
-      { ...aNotificationEvent, messageContent: aMessageContent }
-    );
-
-    expect(mockTransport.sentMail.length).toBe(1);
-    expect(notificationStatusModelMock).toHaveBeenCalledTimes(1);
-
-    expect(isLeft(result)).toBeTruthy();
-    if (isLeft(result)) {
-      expect(isTransient(result.value)).toBeTruthy();
-    }
-  });
 });
-describe("processResolve", () => {
-  it("should call context.done on success", async () => {
-    const result = right({} as any);
 
-    const contextMock = {
-      bindings: {},
-      done: jest.fn()
-    };
-
-    processResolve(result as any, contextMock as any);
-
-    expect(contextMock.done).toHaveBeenCalledTimes(1);
-    expect(contextMock.done.mock.calls[0][0]).toBe(undefined);
-  });
-  it("should retry on transient error", async () => {
-    const result = left(TransientError("err"));
-
-    const contextMock = {
-      bindings: {},
-      done: jest.fn()
-    };
-
-    processResolve(result as any, contextMock as any);
-
-    expect(retryMessageEnqueue).toHaveBeenCalledTimes(1);
-  });
-  it("should call context.done on permanent error", async () => {
-    const result = left(PermanentError("err"));
-
-    const contextMock = {
-      bindings: {},
-      done: jest.fn()
-    };
-
-    processResolve(result as any, contextMock as any);
-
-    expect(contextMock.done).toHaveBeenCalledTimes(1);
-    expect(contextMock.done.mock.calls[0][0]).toBe(undefined);
-  });
-});
 describe("generateHtmlDocument", () => {
   it("should convert markdown to the right html", async () => {
     const subject = "This is the subject" as MessageSubject;
@@ -592,9 +531,6 @@ describe("emailnotificationQueueHandlerIndex", () => {
     await flushPromises();
     expect(contextMock.done).toHaveBeenCalledTimes(1);
     expect(winstonErrorSpy).toHaveBeenCalledTimes(1);
-    expect(winstonErrorSpy).toHaveBeenCalledWith(
-      expect.stringMatching("No valid email notification found in bindings")
-    );
   });
 
   it("should proceed on valid message payload", async () => {
@@ -613,7 +549,7 @@ describe("emailnotificationQueueHandlerIndex", () => {
     const notificationStatusModelSpy = jest
       .spyOn(NotificationStatusModel.prototype, "upsert")
       .mockImplementation(
-        jest.fn(() => Promise.resolve(aRetrievedNotificationStatus))
+        jest.fn(() => Promise.resolve(right(aRetrievedNotificationStatus)))
       );
 
     const nodemailerSpy = jest

--- a/lib/__tests__/emailnotifications_queue_handler.test.ts
+++ b/lib/__tests__/emailnotifications_queue_handler.test.ts
@@ -525,12 +525,12 @@ describe("emailnotificationQueueHandlerIndex", () => {
       log: jest.fn()
     };
     const winstonErrorSpy = jest.spyOn(winston, "error");
-    await index(contextMock as any);
-    expect(contextMock.done).toHaveBeenCalledTimes(1);
+    const ret = await index(contextMock as any);
+    expect(ret).toEqual(undefined);
     expect(winstonErrorSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("should exit in case the message is expired", async () => {
+  it("should stop processing in case the message is expired", async () => {
     const contextMock = {
       bindings: {
         notificationEvent: {
@@ -550,9 +550,9 @@ describe("emailnotificationQueueHandlerIndex", () => {
         sendMail: jest.fn((_, cb) => cb(null, "ok"))
       });
     const winstonErrorSpy = jest.spyOn(winston, "error");
-    await index(contextMock as any);
+    const ret = await index(contextMock as any);
+    expect(ret).toEqual(undefined);
     expect(nodemailerSpy).not.toHaveBeenCalled();
-    expect(contextMock.done).toHaveBeenCalledTimes(1);
     expect(winstonErrorSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -581,12 +581,12 @@ describe("emailnotificationQueueHandlerIndex", () => {
         sendMail: jest.fn((_, cb) => cb(null, "ok"))
       });
 
-    await index(contextMock as any);
+    const ret = await index(contextMock as any);
 
     expect(notificationStatusModelSpy).toHaveBeenCalledTimes(1);
     expect(notificationModelSpy).toHaveBeenCalledTimes(1);
     expect(nodemailerSpy).toHaveBeenCalledTimes(1);
-    expect(contextMock.done).toHaveBeenCalledTimes(1);
+    expect(ret).toEqual(undefined);
   });
 });
 

--- a/lib/__tests__/emailnotifications_queue_handler.test.ts
+++ b/lib/__tests__/emailnotifications_queue_handler.test.ts
@@ -56,7 +56,7 @@ import * as functionConfig from "../../EmailNotificationsQueueHandler/function.j
 import { MessageContent } from "../api/definitions/MessageContent";
 import { NotificationChannelEnum } from "../api/definitions/NotificationChannel";
 import { NotificationChannelStatusValueEnum } from "../api/definitions/NotificationChannelStatusValue";
-import { TimeToLive } from "../api/definitions/TimeToLive";
+import { TimeToLiveSeconds } from "../api/definitions/TimeToLiveSeconds";
 import {
   makeStatusId,
   NotificationStatusModel,
@@ -87,7 +87,7 @@ const aMessage = {
   kind: "INewMessageWithoutContent",
   senderServiceId: "",
   senderUserId: "u123" as NonEmptyString,
-  timeToLive: 3600 as TimeToLive
+  timeToLive: 3600 as TimeToLiveSeconds
 };
 
 const aMessageBodyMarkdown = "test".repeat(80) as MessageBodyMarkdown;

--- a/lib/__tests__/emailnotifications_queue_handler.test.ts
+++ b/lib/__tests__/emailnotifications_queue_handler.test.ts
@@ -72,10 +72,6 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-function flushPromises(): Promise<void> {
-  return new Promise(resolve => setImmediate(resolve));
-}
-
 const aFiscalCode = "FRLFRC74E04B157I" as FiscalCode;
 
 const aMessageId = "A_MESSAGE_ID" as NonEmptyString;
@@ -527,8 +523,7 @@ describe("emailnotificationQueueHandlerIndex", () => {
       log: jest.fn()
     };
     const winstonErrorSpy = jest.spyOn(winston, "error");
-    index(contextMock as any);
-    await flushPromises();
+    await index(contextMock as any);
     expect(contextMock.done).toHaveBeenCalledTimes(1);
     expect(winstonErrorSpy).toHaveBeenCalledTimes(1);
   });
@@ -558,8 +553,7 @@ describe("emailnotificationQueueHandlerIndex", () => {
         sendMail: jest.fn((_, cb) => cb(null, "ok"))
       });
 
-    index(contextMock as any);
-    await flushPromises();
+    await index(contextMock as any);
 
     expect(notificationStatusModelSpy).toHaveBeenCalledTimes(1);
     expect(notificationModelSpy).toHaveBeenCalledTimes(1);

--- a/lib/api/admin_api.ts
+++ b/lib/api/admin_api.ts
@@ -336,7 +336,7 @@ export const specs = {
     NewMessage: {
       type: "object",
       properties: {
-        time_to_live: { $ref: "#/definitions/TimeToLive" },
+        time_to_live: { $ref: "#/definitions/TimeToLiveSeconds" },
         content: { $ref: "#/definitions/MessageContent" },
         default_addresses: { $ref: "#/definitions/NewMessageDefaultAddresses" }
       },
@@ -359,7 +359,7 @@ export const specs = {
       properties: {
         id: { type: "string" },
         fiscal_code: { $ref: "#/definitions/FiscalCode" },
-        time_to_live: { $ref: "#/definitions/TimeToLive" },
+        time_to_live: { $ref: "#/definitions/TimeToLiveSeconds" },
         content: { $ref: "#/definitions/MessageContent" },
         sender_service_id: { type: "string" }
       },
@@ -370,7 +370,7 @@ export const specs = {
       properties: {
         id: { type: "string" },
         fiscal_code: { $ref: "#/definitions/FiscalCode" },
-        time_to_live: { $ref: "#/definitions/TimeToLive" },
+        time_to_live: { $ref: "#/definitions/TimeToLiveSeconds" },
         sender_service_id: { type: "string" }
       },
       required: ["fiscal_code", "sender_service_id"]
@@ -469,11 +469,11 @@ export const specs = {
       description:
         "True if the recipient of a message wants to store its content for later retrieval."
     },
-    TimeToLive: {
+    TimeToLiveSeconds: {
       type: "integer",
       default: 3600,
       minimum: 3600,
-      maximum: 31536000,
+      maximum: 604800,
       description:
         "This parameter specifies for how long (in seconds) the system will try to deliver the message to the channels configured by the user.",
       example: 3600

--- a/lib/api/definitions/CreatedMessageWithContent.ts
+++ b/lib/api/definitions/CreatedMessageWithContent.ts
@@ -8,7 +8,7 @@
 // tslint:disable:object-literal-sort-keys
 
 import { FiscalCode } from "./FiscalCode";
-import { TimeToLive } from "./TimeToLive";
+import { TimeToLiveSeconds } from "./TimeToLiveSeconds";
 import { MessageContent } from "./MessageContent";
 
 /**
@@ -29,7 +29,7 @@ const CreatedMessageWithContentR = t.interface({
 const CreatedMessageWithContentO = t.partial({
   id: t.string,
 
-  time_to_live: TimeToLive,
+  time_to_live: TimeToLiveSeconds,
 
   content: MessageContent
 });

--- a/lib/api/definitions/CreatedMessageWithoutContent.ts
+++ b/lib/api/definitions/CreatedMessageWithoutContent.ts
@@ -8,7 +8,7 @@
 // tslint:disable:object-literal-sort-keys
 
 import { FiscalCode } from "./FiscalCode";
-import { TimeToLive } from "./TimeToLive";
+import { TimeToLiveSeconds } from "./TimeToLiveSeconds";
 
 /**
  *
@@ -28,7 +28,7 @@ const CreatedMessageWithoutContentR = t.interface({
 const CreatedMessageWithoutContentO = t.partial({
   id: t.string,
 
-  time_to_live: TimeToLive
+  time_to_live: TimeToLiveSeconds
 });
 
 export const CreatedMessageWithoutContent = strictInterfaceWithOptionals(

--- a/lib/api/definitions/NewMessage.ts
+++ b/lib/api/definitions/NewMessage.ts
@@ -7,7 +7,7 @@
 // tslint:disable:no-any
 // tslint:disable:object-literal-sort-keys
 
-import { TimeToLive } from "./TimeToLive";
+import { TimeToLiveSeconds } from "./TimeToLiveSeconds";
 import { MessageContent } from "./MessageContent";
 import { NewMessageDefaultAddresses } from "./NewMessageDefaultAddresses";
 
@@ -25,7 +25,7 @@ const NewMessageR = t.interface({
 
 // optional attributes
 const NewMessageO = t.partial({
-  time_to_live: TimeToLive,
+  time_to_live: TimeToLiveSeconds,
 
   default_addresses: NewMessageDefaultAddresses
 });

--- a/lib/api/definitions/TimeToLiveSeconds.ts
+++ b/lib/api/definitions/TimeToLiveSeconds.ts
@@ -17,8 +17,11 @@ import * as t from "io-ts";
 
 import { withDefault } from "../../utils/default";
 
-export type TimeToLive = t.TypeOf<typeof TimeToLiveBase>;
+export type TimeToLiveSeconds = t.TypeOf<typeof TimeToLiveSecondsBase>;
 
-const TimeToLiveBase = WithinRangeNumber(3600, 31536000);
+const TimeToLiveSecondsBase = WithinRangeNumber(3600, 604800);
 
-export const TimeToLive = withDefault(TimeToLiveBase, 3600 as TimeToLive);
+export const TimeToLiveSeconds = withDefault(
+  TimeToLiveSecondsBase,
+  3600 as TimeToLiveSeconds
+);

--- a/lib/api/public_api_v1.ts
+++ b/lib/api/public_api_v1.ts
@@ -350,7 +350,7 @@ export const specs = {
     NewMessage: {
       type: "object",
       properties: {
-        time_to_live: { $ref: "#/definitions/TimeToLive" },
+        time_to_live: { $ref: "#/definitions/TimeToLiveSeconds" },
         content: { $ref: "#/definitions/MessageContent" },
         default_addresses: { $ref: "#/definitions/NewMessageDefaultAddresses" }
       },
@@ -373,7 +373,7 @@ export const specs = {
       properties: {
         id: { type: "string" },
         fiscal_code: { $ref: "#/definitions/FiscalCode" },
-        time_to_live: { $ref: "#/definitions/TimeToLive" },
+        time_to_live: { $ref: "#/definitions/TimeToLiveSeconds" },
         content: { $ref: "#/definitions/MessageContent" },
         sender_service_id: { type: "string" }
       },
@@ -384,7 +384,7 @@ export const specs = {
       properties: {
         id: { type: "string" },
         fiscal_code: { $ref: "#/definitions/FiscalCode" },
-        time_to_live: { $ref: "#/definitions/TimeToLive" },
+        time_to_live: { $ref: "#/definitions/TimeToLiveSeconds" },
         sender_service_id: { type: "string" }
       },
       required: ["fiscal_code", "sender_service_id"]
@@ -483,11 +483,11 @@ export const specs = {
       description:
         "True if the recipient of a message wants to store its content for later retrieval."
     },
-    TimeToLive: {
+    TimeToLiveSeconds: {
       type: "integer",
       default: 3600,
       minimum: 3600,
-      maximum: 31536000,
+      maximum: 604800,
       description:
         "This parameter specifies for how long (in seconds) the system will try to deliver the message to the channels configured by the user.",
       example: 3600

--- a/lib/controllers/__tests__/messages.test.ts
+++ b/lib/controllers/__tests__/messages.test.ts
@@ -14,7 +14,6 @@ import { EmailAddress } from "../../api/definitions/EmailAddress";
 import { FiscalCode } from "../../api/definitions/FiscalCode";
 import { MessageBodyMarkdown } from "../../api/definitions/MessageBodyMarkdown";
 import { MessageSubject } from "../../api/definitions/MessageSubject";
-import { NewMessage as ApiNewMessage } from "../../api/definitions/NewMessage";
 
 import {
   IAzureApiAuthorization,
@@ -27,7 +26,7 @@ import { MessageContent } from "../../api/definitions/MessageContent";
 import { MessageResponseWithoutContent } from "../../api/definitions/MessageResponseWithoutContent";
 import { NotificationChannelEnum } from "../../api/definitions/NotificationChannel";
 import { NotificationChannelStatusValueEnum } from "../../api/definitions/NotificationChannelStatusValue";
-import { TimeToLive } from "../../api/definitions/TimeToLive";
+import { TimeToLiveSeconds } from "../../api/definitions/TimeToLiveSeconds";
 import {
   NewMessage,
   NewMessageWithContent,
@@ -44,6 +43,7 @@ import {
 } from "../../models/notification_status";
 import { NonNegativeNumber } from "../../utils/numbers";
 import {
+  ApiNewMessageWithDefaults,
   CreateMessage,
   CreateMessageHandler,
   GetMessageHandler,
@@ -95,11 +95,11 @@ const aUserAuthenticationTrustedApplication: IAzureApiAuthorization = {
   userId: "u123" as NonEmptyString
 };
 
-const aMessagePayload: ApiNewMessage = {
+const aMessagePayload: ApiNewMessageWithDefaults = {
   content: {
     markdown: aMessageBodyMarkdown
   },
-  time_to_live: 3600 as TimeToLive
+  time_to_live: 3600 as TimeToLiveSeconds
 };
 
 const aCustomSubject = "A custom subject" as MessageSubject;
@@ -113,7 +113,7 @@ const aNewMessageWithoutContent: NewMessageWithoutContent = {
   kind: "INewMessageWithoutContent",
   senderServiceId: "test" as ModelId,
   senderUserId: "u123" as NonEmptyString,
-  timeToLive: 3600 as TimeToLive
+  timeToLiveSeconds: 3600 as TimeToLiveSeconds
 };
 
 const aRetrievedMessageWithoutContent: RetrievedMessageWithoutContent = {
@@ -487,7 +487,7 @@ describe("CreateMessageHandler", () => {
       log: jest.fn()
     };
 
-    const messagePayload: ApiNewMessage = {
+    const messagePayload: ApiNewMessageWithDefaults = {
       ...aMessagePayload,
       default_addresses: {
         email: "test@example.com" as EmailAddress
@@ -582,7 +582,7 @@ describe("CreateMessageHandler", () => {
       log: jest.fn()
     };
 
-    const messagePayload: ApiNewMessage = {
+    const messagePayload: ApiNewMessageWithDefaults = {
       ...aMessagePayload,
       default_addresses: {
         email: "test@example.com" as EmailAddress
@@ -979,6 +979,12 @@ describe("MessagePayloadMiddleware", () => {
         default_addresses: {
           email: "test@example.com"
         }
+      },
+      {
+        content: {
+          markdown: "test".repeat(100)
+        },
+        time_to_live: 4000
       }
     ];
     await Promise.all(
@@ -991,7 +997,7 @@ describe("MessagePayloadMiddleware", () => {
         expect(result.value).toEqual({
           ...f,
           default_addresses: f.default_addresses,
-          time_to_live: 3600
+          time_to_live: f.time_to_live || 3600
         });
       })
     );

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -341,7 +341,7 @@ export function index(context: ContextWithBindings): void {
   }
   const createdMessageEvent = errorOrCreatedMessageEvent.value;
 
-  // it is an CreatedMessageEvent
+  // it is a CreatedMessageEvent
   const newMessageWithContent = createdMessageEvent.message;
   const defaultAddresses = fromNullable(createdMessageEvent.defaultAddresses);
   const senderMetadata = createdMessageEvent.senderMetadata;

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -411,13 +411,11 @@ export async function index(context: ContextWithBindings): Promise<void> {
       errorOrNotification.fold(
         error => processRuntimeError(queueService, error, context.bindingData),
         notification =>
-          Promise.resolve(
-            processSuccess(
-              notificationStatusModel,
-              notification,
-              newMessageWithContent,
-              senderMetadata
-            )
+          processSuccess(
+            notificationStatusModel,
+            notification,
+            newMessageWithContent,
+            senderMetadata
           )
       )
     )
@@ -428,7 +426,7 @@ export async function index(context: ContextWithBindings): Promise<void> {
           context.done(shouldTriggerARetry ? true : undefined);
         },
         outputBindings =>
-          // success ! lets see if we have some output bindings
+          // success ! lets see if we have some bindings to output
           outputBindings.foldL(
             () => context.done(),
             bindings => context.done(undefined, bindings)

--- a/lib/emailnotifications_queue_handler.ts
+++ b/lib/emailnotifications_queue_handler.ts
@@ -118,7 +118,7 @@ const ContextWithBindings = t.interface({
 
 type ContextWithBindings = t.TypeOf<typeof ContextWithBindings> & IContext;
 
-type OutputBindings = undefined;
+type OutputBindings = never;
 
 /**
  * Generates the HTML for the email from the Markdown content and the subject

--- a/lib/emailnotifications_queue_handler.ts
+++ b/lib/emailnotifications_queue_handler.ts
@@ -307,9 +307,9 @@ export async function handleNotification(
   return right(emailNotificationEvent);
 }
 
-async function processGenericError(
-  error: Error,
-  notificationStatusUpdater: NotificationStatusUpdater
+export async function processGenericError(
+  notificationStatusUpdater: NotificationStatusUpdater,
+  error: Error
 ): Promise<void> {
   winston.error(
     `EmailNotificationQueueHandler|"Unexpected error|${error.message}`
@@ -347,7 +347,7 @@ export async function processRuntimeError(
   }
 }
 
-async function processSuccess(
+export async function processSuccess(
   emailNotificationEvent: NotificationEvent,
   notificationStatusUpdater: NotificationStatusUpdater
 ): Promise<Either<never, Option<OutputBindings>>> {
@@ -470,7 +470,7 @@ export async function index(context: ContextWithBindings): Promise<void> {
       );
     })
     .catch(async error => {
-      await processGenericError(error, notificationStatusUpdater);
+      await processGenericError(notificationStatusUpdater, error);
       context.done();
     });
 }

--- a/lib/emailnotifications_queue_handler.ts
+++ b/lib/emailnotifications_queue_handler.ts
@@ -448,7 +448,7 @@ export function index(context: ContextWithBindings): void {
         async notificationIsExpired => {
           if (notificationIsExpired) {
             await notificationStatusUpdater(
-              NotificationChannelStatusValueEnum.EXPIRED
+              NotificationChannelStatusValueEnum.FAILED
             );
           }
           context.done();

--- a/lib/models/__tests__/created_message_event.test.ts
+++ b/lib/models/__tests__/created_message_event.test.ts
@@ -2,6 +2,7 @@
 
 import { CreatedMessageEvent } from "../created_message_event";
 
+import { isRight } from "fp-ts/lib/Either";
 import { MessageBodyMarkdown } from "../../api/definitions/MessageBodyMarkdown";
 
 const aMessageBodyMarkdown = "test".repeat(80) as MessageBodyMarkdown;
@@ -18,14 +19,15 @@ describe("", () => {
           _self:
             "dbs/LgNRAA==/colls/LgNRANj9nwA=/docs/LgNRANj9nwBgAAAAAAAAAA==/",
           _ts: 1505754168,
+          content: {
+            markdown: aMessageBodyMarkdown
+          },
+          createdAt: new Date().toISOString(),
           fiscalCode: "FRLFRC73E04B157I",
           id: "01BTAZ2HS1PWDJERA510FDXYV4",
           kind: "RetrievedMessage",
           senderServiceId: "test",
           senderUserId: "u123"
-        },
-        messageContent: {
-          markdown: aMessageBodyMarkdown
         },
         senderMetadata: {
           departmentName: "IT",
@@ -35,7 +37,8 @@ describe("", () => {
       }
     ];
     payloads.forEach(payload => {
-      expect(CreatedMessageEvent.is(payload)).toBeTruthy();
+      const event = CreatedMessageEvent.decode(payload);
+      expect(isRight(event)).toBeTruthy();
     });
   });
 });

--- a/lib/models/__tests__/message.test.ts
+++ b/lib/models/__tests__/message.test.ts
@@ -24,6 +24,7 @@ import {
 import { ModelId } from "../../utils/documentdb_model_versioned";
 
 jest.mock("../../utils/azure_storage");
+import { TimeToLive } from "../../api/definitions/TimeToLive";
 import * as azureStorageUtils from "../../utils/azure_storage";
 
 const MESSAGE_CONTAINER_NAME = "message-content" as NonEmptyString;
@@ -42,13 +43,27 @@ const aMessageContent: MessageContent = {
 
 const aFiscalCode = "FRLFRC74E04B157I" as FiscalCode;
 
-const aNewMessageWithContent: NewMessageWithContent = {
+const aSerializedNewMessageWithContent = {
   content: aMessageContent,
+  createdAt: new Date().toISOString(),
   fiscalCode: aFiscalCode,
   id: "A_MESSAGE_ID" as NonEmptyString,
-  kind: "INewMessageWithContent",
   senderServiceId: "agid" as ModelId,
-  senderUserId: "u123" as NonEmptyString
+  senderUserId: "u123" as NonEmptyString,
+  timeToLive: 3600 as TimeToLive
+};
+
+const aNewMessageWithContent: NewMessageWithContent = {
+  ...aSerializedNewMessageWithContent,
+  createdAt: new Date(),
+  kind: "INewMessageWithContent"
+};
+
+const aSerializedRetrievedMessageWithContent = {
+  ...aSerializedNewMessageWithContent,
+  _self: "xyz",
+  _ts: "xyz",
+  kind: "IRetrievedMessageWithContent"
 };
 
 const aRetrievedMessageWithContent: RetrievedMessageWithContent = {
@@ -62,7 +77,7 @@ describe("createMessage", () => {
   it("should create a new Message", async () => {
     const clientMock = {
       createDocument: jest.fn((_, __, ___, cb) =>
-        cb(undefined, aRetrievedMessageWithContent)
+        cb(undefined, aSerializedRetrievedMessageWithContent)
       )
     };
 
@@ -123,7 +138,7 @@ describe("find", () => {
   it("should return an existing message", async () => {
     const clientMock = {
       readDocument: jest.fn((_, __, cb) =>
-        cb(undefined, aRetrievedMessageWithContent)
+        cb(undefined, aSerializedRetrievedMessageWithContent)
       )
     };
 
@@ -148,7 +163,10 @@ describe("find", () => {
     expect(isRight(result)).toBeTruthy();
     if (isRight(result)) {
       expect(result.value.isSome()).toBeTruthy();
-      expect(result.value.toUndefined()).toEqual(aRetrievedMessageWithContent);
+      expect(result.value.toUndefined()).toEqual({
+        ...aRetrievedMessageWithContent,
+        createdAt: expect.any(Date)
+      });
     }
   });
 
@@ -233,7 +251,7 @@ describe("findMessageForRecipient", () => {
   it("should return the messages if the recipient matches", async () => {
     const clientMock = {
       readDocument: jest.fn((_, __, cb) =>
-        cb(undefined, aRetrievedMessageWithContent)
+        cb(undefined, aSerializedRetrievedMessageWithContent)
       )
     };
 
@@ -258,14 +276,17 @@ describe("findMessageForRecipient", () => {
     expect(isRight(result)).toBeTruthy();
     if (isRight(result)) {
       expect(result.value.isSome()).toBeTruthy();
-      expect(result.value.toUndefined()).toEqual(aRetrievedMessageWithContent);
+      expect(result.value.toUndefined()).toEqual({
+        ...aRetrievedMessageWithContent,
+        createdAt: expect.any(Date)
+      });
     }
   });
 
   it("should return an empty value if the recipient doesn't match", async () => {
     const clientMock = {
       readDocument: jest.fn((_, __, cb) =>
-        cb(undefined, aRetrievedMessageWithContent)
+        cb(undefined, aSerializedRetrievedMessageWithContent)
       )
     };
 

--- a/lib/models/__tests__/message.test.ts
+++ b/lib/models/__tests__/message.test.ts
@@ -24,7 +24,7 @@ import {
 import { ModelId } from "../../utils/documentdb_model_versioned";
 
 jest.mock("../../utils/azure_storage");
-import { TimeToLive } from "../../api/definitions/TimeToLive";
+import { TimeToLiveSeconds } from "../../api/definitions/TimeToLiveSeconds";
 import * as azureStorageUtils from "../../utils/azure_storage";
 
 const MESSAGE_CONTAINER_NAME = "message-content" as NonEmptyString;
@@ -50,7 +50,7 @@ const aSerializedNewMessageWithContent = {
   id: "A_MESSAGE_ID" as NonEmptyString,
   senderServiceId: "agid" as ModelId,
   senderUserId: "u123" as NonEmptyString,
-  timeToLive: 3600 as TimeToLive
+  timeToLiveSeconds: 3600 as TimeToLiveSeconds
 };
 
 const aNewMessageWithContent: NewMessageWithContent = {

--- a/lib/models/__tests__/notification_event.test.ts
+++ b/lib/models/__tests__/notification_event.test.ts
@@ -9,6 +9,8 @@ import { NotificationEvent } from "../notification_event";
 
 import { MessageContent } from "../../api/definitions/MessageContent";
 
+import { isRight } from "fp-ts/lib/Either";
+import { TimeToLive } from "../../api/definitions/TimeToLive";
 import { CreatedMessageEventSenderMetadata } from "../created_message_sender_metadata";
 
 const aMessageId = "A_MESSAGE_ID" as NonEmptyString;
@@ -18,6 +20,17 @@ const aMessageBodyMarkdown = "test".repeat(80) as MessageBodyMarkdown;
 
 const aMessageContent: MessageContent = {
   markdown: aMessageBodyMarkdown
+};
+
+const aMessage = {
+  content: aMessageContent,
+  createdAt: new Date().toISOString(),
+  fiscalCode: "FRLFRC74E04B157I",
+  id: aMessageId,
+  kind: "INewMessageWithoutContent",
+  senderServiceId: "",
+  senderUserId: "u123" as NonEmptyString,
+  timeToLive: 3600 as TimeToLive
 };
 
 const aSenderMetadata: CreatedMessageEventSenderMetadata = {
@@ -30,14 +43,16 @@ describe("isNotificationEvent", () => {
   it("should return true for valid payloads", () => {
     const fixtures: ReadonlyArray<any> = [
       {
-        messageContent: aMessageContent,
-        messageId: aMessageId,
+        message: aMessage,
         notificationId: aNotificationId,
         senderMetadata: aSenderMetadata
       }
     ];
 
-    fixtures.forEach(f => expect(NotificationEvent.is(f)).toBeTruthy());
+    fixtures.forEach(f => {
+      const errorOrNotification = NotificationEvent.decode(f);
+      expect(isRight(errorOrNotification)).toBeTruthy();
+    });
   });
 
   it("should return false for invalid payloads", () => {
@@ -67,6 +82,9 @@ describe("isNotificationEvent", () => {
       }
     ];
 
-    fixtures.forEach(f => expect(NotificationEvent.is(f)).toBeFalsy());
+    fixtures.forEach(f => {
+      const errorOrNotification = NotificationEvent.decode(f);
+      expect(isRight(errorOrNotification)).toBeFalsy();
+    });
   });
 });

--- a/lib/models/__tests__/notification_event.test.ts
+++ b/lib/models/__tests__/notification_event.test.ts
@@ -10,7 +10,7 @@ import { NotificationEvent } from "../notification_event";
 import { MessageContent } from "../../api/definitions/MessageContent";
 
 import { isRight } from "fp-ts/lib/Either";
-import { TimeToLive } from "../../api/definitions/TimeToLive";
+import { TimeToLiveSeconds } from "../../api/definitions/TimeToLiveSeconds";
 import { CreatedMessageEventSenderMetadata } from "../created_message_sender_metadata";
 
 const aMessageId = "A_MESSAGE_ID" as NonEmptyString;
@@ -30,7 +30,7 @@ const aMessage = {
   kind: "INewMessageWithoutContent",
   senderServiceId: "",
   senderUserId: "u123" as NonEmptyString,
-  timeToLive: 3600 as TimeToLive
+  timeToLive: 3600 as TimeToLiveSeconds
 };
 
 const aSenderMetadata: CreatedMessageEventSenderMetadata = {

--- a/lib/models/created_message_event.ts
+++ b/lib/models/created_message_event.ts
@@ -7,16 +7,14 @@
 
 import * as t from "io-ts";
 
-import { MessageContent } from "../api/definitions/MessageContent";
 import { NewMessageDefaultAddresses } from "../api/definitions/NewMessageDefaultAddresses";
 
-import { NewMessageWithoutContent } from "./message";
+import { NewMessageWithContent } from "./message";
 
 import { CreatedMessageEventSenderMetadata } from "./created_message_sender_metadata";
 
 const CreatedMessageEventR = t.interface({
-  message: NewMessageWithoutContent,
-  messageContent: MessageContent,
+  message: NewMessageWithContent,
   senderMetadata: CreatedMessageEventSenderMetadata
 });
 

--- a/lib/models/message.ts
+++ b/lib/models/message.ts
@@ -2,7 +2,7 @@ import * as t from "io-ts";
 
 import * as DocumentDb from "documentdb";
 
-import { tag } from "../utils/types";
+import { pick, tag } from "../utils/types";
 
 import * as DocumentDbUtils from "../utils/documentdb";
 import { DocumentDbModel } from "../utils/documentdb_model";
@@ -16,22 +16,33 @@ import { MessageContent } from "../api/definitions/MessageContent";
 import { FiscalCode } from "../api/definitions/FiscalCode";
 
 import { BlobService } from "azure-storage";
+import { Timestamp } from "../api/definitions/Timestamp";
+import { TimeToLive } from "../api/definitions/TimeToLive";
 import { getBlobAsText, upsertBlobFromObject } from "../utils/azure_storage";
 import { iteratorToArray } from "../utils/documentdb";
 import { readableReport } from "../utils/validation_reporters";
 
 const MESSAGE_BLOB_STORAGE_SUFFIX = ".json";
 
-const MessageBase = t.interface({
-  // the fiscal code of the recipient
-  fiscalCode: FiscalCode,
+const MessageBase = t.interface(
+  {
+    // the fiscal code of the recipient
+    fiscalCode: FiscalCode,
 
-  // the identifier of the service of the sender
-  senderServiceId: t.string,
+    // the identifier of the service of the sender
+    senderServiceId: t.string,
 
-  // the userId of the sender (this is opaque and depends on the API gateway)
-  senderUserId: NonEmptyString
-});
+    // the userId of the sender (this is opaque and depends on the API gateway)
+    senderUserId: NonEmptyString,
+
+    // time to live in seconds
+    timeToLive: TimeToLive,
+
+    // timestamp: the message was accepted by the system
+    createdAt: Timestamp
+  },
+  "MessageBase"
+);
 
 /**
  * The attributes common to all types of Message
@@ -141,6 +152,15 @@ export type RetrievedMessageWithoutContent = t.TypeOf<
   typeof RetrievedMessageWithoutContent
 >;
 
+export const NotExpiredMessage = t.refinement(
+  MessageBase,
+  message =>
+    Date.now() - message.createdAt.getTime() <= message.timeToLive * 1000,
+  "NotExpiredMessage"
+);
+
+export type NotExpiredMessage = t.TypeOf<typeof NotExpiredMessage>;
+
 /**
  * A (previously saved) retrieved Message
  */
@@ -153,32 +173,24 @@ export const RetrievedMessage = t.union([
 export type RetrievedMessage = t.TypeOf<typeof RetrievedMessage>;
 
 function toBaseType(o: RetrievedMessage): Message {
-  if (RetrievedMessageWithContent.is(o)) {
-    return {
-      content: o.content,
-      fiscalCode: o.fiscalCode,
-      senderServiceId: o.senderServiceId,
-      senderUserId: o.senderUserId
-    };
-  } else {
-    return {
-      fiscalCode: o.fiscalCode,
-      senderServiceId: o.senderServiceId,
-      senderUserId: o.senderUserId
-    };
-  }
+  const props: ReadonlyArray<keyof Message> = [
+    "fiscalCode",
+    "senderServiceId",
+    "senderUserId",
+    "timeToLive",
+    "createdAt"
+  ];
+  return RetrievedMessageWithContent.is(o)
+    ? pick(["content", ...props], o)
+    : pick(props, o);
 }
 
 function toRetrieved(result: DocumentDb.RetrievedDocument): RetrievedMessage {
-  if (RetrievedMessageWithContent.is(result)) {
-    return result;
-  }
-  if (RetrievedMessageWithoutContent.is(result)) {
-    return result;
-  }
-  throw new Error(
-    "retrieved result was neither a RetrievedMessageWithContent nor a RetrievedMessageWithoutContent"
-  );
+  return RetrievedMessage.decode(result).getOrElseL(errs => {
+    throw new Error(
+      "Retrieved result wasn't a RetrievedMessage: " + readableReport(errs)
+    );
+  });
 }
 
 function blobIdFromMessageId(messageId: string): string {

--- a/lib/models/notification_event.ts
+++ b/lib/models/notification_event.ts
@@ -3,7 +3,7 @@ import * as t from "io-ts";
 import { NonEmptyString } from "../utils/strings";
 
 import { CreatedMessageEventSenderMetadata } from "./created_message_sender_metadata";
-import { ActiveMessage, NewMessageWithContent } from "./message";
+import { NewMessageWithContent } from "./message";
 
 /**
  * Payload of a notification event.
@@ -12,7 +12,7 @@ import { ActiveMessage, NewMessageWithContent } from "./message";
  * have been configured for that notification.
  */
 export const NotificationEvent = t.interface({
-  message: t.intersection([NewMessageWithContent, ActiveMessage]),
+  message: NewMessageWithContent,
   notificationId: NonEmptyString,
   senderMetadata: CreatedMessageEventSenderMetadata
 });

--- a/lib/models/notification_event.ts
+++ b/lib/models/notification_event.ts
@@ -3,7 +3,7 @@ import * as t from "io-ts";
 import { NonEmptyString } from "../utils/strings";
 
 import { CreatedMessageEventSenderMetadata } from "./created_message_sender_metadata";
-import { NewMessageWithContent, NotExpiredMessage } from "./message";
+import { ActiveMessage, NewMessageWithContent } from "./message";
 
 /**
  * Payload of a notification event.
@@ -12,7 +12,7 @@ import { NewMessageWithContent, NotExpiredMessage } from "./message";
  * have been configured for that notification.
  */
 export const NotificationEvent = t.interface({
-  message: t.intersection([NewMessageWithContent, NotExpiredMessage]),
+  message: t.intersection([NewMessageWithContent, ActiveMessage]),
   notificationId: NonEmptyString,
   senderMetadata: CreatedMessageEventSenderMetadata
 });

--- a/lib/models/notification_event.ts
+++ b/lib/models/notification_event.ts
@@ -2,9 +2,8 @@ import * as t from "io-ts";
 
 import { NonEmptyString } from "../utils/strings";
 
-import { MessageContent } from "../api/definitions/MessageContent";
-
 import { CreatedMessageEventSenderMetadata } from "./created_message_sender_metadata";
+import { NewMessageWithContent, NotExpiredMessage } from "./message";
 
 /**
  * Payload of a notification event.
@@ -13,8 +12,7 @@ import { CreatedMessageEventSenderMetadata } from "./created_message_sender_meta
  * have been configured for that notification.
  */
 export const NotificationEvent = t.interface({
-  messageContent: MessageContent,
-  messageId: NonEmptyString,
+  message: t.intersection([NewMessageWithContent, NotExpiredMessage]),
   notificationId: NonEmptyString,
   senderMetadata: CreatedMessageEventSenderMetadata
 });

--- a/lib/utils/azure_queues.ts
+++ b/lib/utils/azure_queues.ts
@@ -14,7 +14,9 @@ export interface IQueueMessage extends QueueService.QueueMessageResult {
   readonly queueTrigger: string;
 }
 
-// Any delay must be less than 7 days (< 604800 seconds)
+// Any delay must be less than 7 days (< 604800 seconds).
+// See the maximum value of the TimeToLiveSeconds field
+// in the OpenApi specs (api/definitions.yaml)
 const MAX_BACKOFF_MS = 7 * 24 * 3600 * 1000;
 const MIN_BACKOFF_MS = 285;
 

--- a/lib/utils/errors.ts
+++ b/lib/utils/errors.ts
@@ -33,5 +33,6 @@ export const PermanentError = RuntimeError(ErrorTypes.PermanentError);
 
 export type RuntimeError = TransientError | PermanentError;
 
-export const isTransient = (error: RuntimeError): error is TransientError =>
-  error.kind === ErrorTypes.TransientError;
+// tslint:disable-next-line:no-any
+export const isTransient = (error: any): error is TransientError =>
+  error.kind && error.kind === ErrorTypes.TransientError;


### PR DESCRIPTION
Between the main changes, note that with this PR [the whole Message is passed in the NotificationEvent](https://github.com/teamdigitale/digital-citizenship-functions/pull/158/files#diff-369872c88999ee654209f0771aaa8f25R129) (queue) while actually we pass only some fields:

- added two fields (createAt, timeToLive) to the MessageModel
- added a type (NotExpiredMessage) that checks that Date.now() < createdAt + timeToLive
- update notification status in case of error / expire
- refactor queue handlers to simplify error handling (ie. avoid try / catch blocks in index, pushed error logging at the end of the index method) and avoiding calling context.done (return a promise instead)