### PR TITLE
[#155679212] fix superagent mock and avoid jest tests to stuck

### DIFF
--- a/__mocks__/superagent.ts
+++ b/__mocks__/superagent.ts
@@ -1,0 +1,44 @@
+/**
+ * Implements a superagent mock to use inside jest tests.
+ * Avoids real calls to some HTTP backend.
+ *
+ * https://github.com/visionmedia/superagent
+ *
+ */
+// tslint:disable
+let __response = {};
+let __requestSpy = (_: any) => ({});
+let __responseSpy = (_: any) => ({});
+
+const request = jest.fn().mockReturnValue({
+  get: jest.fn(function(req: any) {
+    __requestSpy(req);
+    return request;
+  }),
+  post: jest.fn(function(req: any) {
+    __requestSpy(req);
+    return request;
+  }),
+  send: jest.fn().mockImplementation((req: any) => {
+    __requestSpy(req);
+    __responseSpy((__response as any).body);
+    return Promise.resolve(__response);
+  }),
+  timeout: jest.fn().mockReturnThis(),
+  __setResponse: (response: any) => {
+    __response = response;
+  },
+  __setRequestSpy: (requestSpy: any) => {
+    __requestSpy = requestSpy;
+  },
+  __setResponseSpy: (responseSpy: any) => {
+    __responseSpy = responseSpy;
+  },
+  __resetMocks: () => {
+    __requestSpy = (_: any) => ({});
+    __responseSpy = (_: any) => ({});
+    __response = {};
+  }
+});
+
+export = request;

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "prettier": "^1.7.0",
     "run-sequence": "^2.2.0",
     "semver": "^5.4.1",
-    "superagent-mock": "^3.6.0",
     "swagger-parser": "^3.4.2",
     "ts-jest": "^22.0.0",
     "ts-node": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6719,10 +6719,6 @@ subarg@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
-superagent-mock@^3.6.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/superagent-mock/-/superagent-mock-3.7.0.tgz#d424909e2dbb0bd0e5ab213ef8df91e3cbbcd613"
-
 superagent@^3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.2.tgz#e4a11b9d047f7d3efeb3bbe536d9ec0021d16403"


### PR DESCRIPTION
It looks like superagent-mock does not work with promises as it expects the metehod end() to be called.
As we don't want to fallback to old style callbacks, it's necessary to provide a custom superagent mock implementation. An alternative is to fake NodeJS http requests at a lower level with something like https://github.com/node-nock/nock