### PR TITLE
[#150737636] add message status

### DIFF
--- a/api/definitions.yaml
+++ b/api/definitions.yaml
@@ -37,8 +37,14 @@ NotificationChannel:
   example: EMAIL
 NotificationChannelStatusValue:
   type: string
+    The status of a notification (one for each channel).
+    "SENT_TO_CHANNEL": the notification was succesfully sent to the channel (ie. email or push notification)
+    "THROTTLED": a temporary failure caused a retry during the notification processing;
+                 any notification associated with this channel will be delayed until the message expires
+    "EXPIRED": the message expired before the notification could be sent;
+               this means that the maximum message time to live was reached so no notification will be sent for this channel
+    "FAILED": a permanent failure caused the process to exit with an error, no notification for this channel will be sent for this message
   x-extensible-enum:
-    - QUEUED
     - SENT_TO_CHANNEL
     - THROTTLED
     - EXPIRED

--- a/api/definitions.yaml
+++ b/api/definitions.yaml
@@ -37,6 +37,7 @@ NotificationChannel:
   example: EMAIL
 NotificationChannelStatusValue:
   type: string
+  description: |-
     The status of a notification (one for each channel).
     "SENT_TO_CHANNEL": the notification was succesfully sent to the channel (ie. email or push notification)
     "THROTTLED": a temporary failure caused a retry during the notification processing;

--- a/api/definitions.yaml
+++ b/api/definitions.yaml
@@ -50,12 +50,14 @@ NotificationChannelStatus:
       $ref: "#/NotificationChannel"
     status:
       $ref: "#/NotificationChannelStatusValue"
-    updateAt:
+    updated_at:
       $ref: "#/Timestamp"
+    version:
+      type: integer
   required:
     - channel
     - status
-    - updateAt
+    - updated_at
 MessageContent:
   type: object
   properties:
@@ -78,18 +80,31 @@ NewMessage:
     - content
 MessageStatusValue:
   type: string
+  description: |-
+    The processing status of a message.
+    "ACCEPTED": the message has been accepted and will be processed so we can try to notify the recipient
+    "THROTTLED": a temporary failure caused a retry during the message processing;
+                 any notification associated with this message will be delayed for a maximum of 7 days
+    "FAILED": a permanent failure caused the process to exit with an error, no notification will be sent for this message
+    "PROCESSED": the message was processed succesfully, we'll try to send a notification for each of the selected channels
   x-extensible-enum:
-    - PROCESSING
     - ACCEPTED
+    - THROTTLED
     - FAILED
+    - PROCESSED
   example: ACCEPTED
 MessageStatus:
   type: object
   properties:
     status:
       $ref: "#/MessageStatusValue"
-    updateAt:
+    updated_at:
       $ref: "#/Timestamp"
+    version:
+      type: integer
+  required:
+    - status
+    - updated_at
 CreatedMessageWithContent:
   type: object
   properties:
@@ -132,6 +147,8 @@ MessageResponseWithContent:
       $ref: "#/CreatedMessageWithContent"
     notification:
       $ref: "#/MessageResponseNotificationStatus"
+    status:
+      $ref: "#/MessageStatusValue"
   required:
     - message
 MessageResponseWithoutContent:
@@ -141,6 +158,8 @@ MessageResponseWithoutContent:
       $ref: "#/CreatedMessageWithoutContent"
     notification:
       $ref: "#/MessageResponseNotificationStatus"
+    status:
+      $ref: "#/MessageStatusValue"
   required:
     - message
 FiscalCode:

--- a/api/definitions.yaml
+++ b/api/definitions.yaml
@@ -41,10 +41,10 @@ NotificationChannelStatusValue:
     The status of a notification (one for each channel).
     "SENT_TO_CHANNEL": the notification was succesfully sent to the channel (ie. email or push notification)
     "THROTTLED": a temporary failure caused a retry during the notification processing;
-                 any notification associated with this channel will be delayed until the message expires
+      the notification associated with this channel will be delayed until the message expires
     "EXPIRED": the message expired before the notification could be sent;
-               this means that the maximum message time to live was reached so no notification will be sent for this channel
-    "FAILED": a permanent failure caused the process to exit with an error, no notification for this channel will be sent for this message
+      this means that the maximum message time to live was reached so no notification will be sent to this channel
+    "FAILED": a permanent failure caused the process to exit with an error, no notification will be sent to this channel
   x-extensible-enum:
     - SENT_TO_CHANNEL
     - THROTTLED
@@ -92,7 +92,7 @@ MessageStatusValue:
     The processing status of a message.
     "ACCEPTED": the message has been accepted and will be processed so we can try to notify the recipient
     "THROTTLED": a temporary failure caused a retry during the message processing;
-                 any notification associated with this message will be delayed for a maximum of 7 days
+      any notification associated with this message will be delayed for a maximum of 7 days
     "FAILED": a permanent failure caused the process to exit with an error, no notification will be sent for this message
     "PROCESSED": the message was processed succesfully, we'll try to send a notification for each of the selected channels
   x-extensible-enum:

--- a/api/definitions.yaml
+++ b/api/definitions.yaml
@@ -39,18 +39,18 @@ NotificationChannelStatusValue:
   type: string
   description: |-
     The status of a notification (one for each channel).
-    "SENT_TO_CHANNEL": the notification was succesfully sent to the channel (ie. email or push notification)
+    "SENT": the notification was succesfully sent to the channel (ie. email or push notification)
     "THROTTLED": a temporary failure caused a retry during the notification processing;
-      the notification associated with this channel will be delayed until the message expires
+      the notification associated with this channel will be delayed for a maximum of 7 days or until the message expires
     "EXPIRED": the message expired before the notification could be sent;
-      this means that the maximum message time to live was reached so no notification will be sent to this channel
+      this means that the maximum message time to live was reached; no notification will be sent to this channel
     "FAILED": a permanent failure caused the process to exit with an error, no notification will be sent to this channel
   x-extensible-enum:
-    - SENT_TO_CHANNEL
+    - SENT
     - THROTTLED
     - EXPIRED
     - FAILED
-  example: SENT_TO_CHANNEL
+  example: SENT
 NotificationChannelStatus:
   type: object
   properties:
@@ -90,11 +90,13 @@ MessageStatusValue:
   type: string
   description: |-
     The processing status of a message.
-    "ACCEPTED": the message has been accepted and will be processed so we can try to notify the recipient
+    "ACCEPTED": the message has been accepted and will be processed for delivery;
+      we'll try to store its content in the user's inbox and notify him on his preferred channels
     "THROTTLED": a temporary failure caused a retry during the message processing;
       any notification associated with this message will be delayed for a maximum of 7 days
     "FAILED": a permanent failure caused the process to exit with an error, no notification will be sent for this message
-    "PROCESSED": the message was processed succesfully, we'll try to send a notification for each of the selected channels
+    "PROCESSED": the message was succesfully processed and is now stored in the user's inbox;
+      we'll try to send a notification for each of the selected channels
   x-extensible-enum:
     - ACCEPTED
     - THROTTLED

--- a/api/definitions.yaml
+++ b/api/definitions.yaml
@@ -40,6 +40,7 @@ NotificationChannelStatusValue:
   x-extensible-enum:
     - QUEUED
     - SENT_TO_CHANNEL
+    - THROTTLED
     - EXPIRED
     - FAILED
   example: SENT_TO_CHANNEL

--- a/api/public_api_v1.yaml
+++ b/api/public_api_v1.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 0.0.2
+  version: 0.0.3
   title: Digital Citizenship API
   description: Digital Citizenship API.
 basePath: "/api/v1"

--- a/lib/__tests__/created_message_queue_handler.test.ts
+++ b/lib/__tests__/created_message_queue_handler.test.ts
@@ -181,8 +181,9 @@ describe("createdMessageQueueIndex", () => {
         throw new Error("findOneProfileByFiscalCodeErr");
       });
 
-    const messageStatusSpy = jest.spyOn(MessageStatusModel.prototype, "upsert");
-
+    const messageStatusSpy = jest
+      .spyOn(MessageStatusModel.prototype, "upsert")
+      .mockReturnValue(Promise.resolve(right(none)));
     const ret = await index(contextMock as any);
     expect(ret).toEqual(undefined);
     expect(messageStatusSpy).toHaveBeenCalledWith(
@@ -231,6 +232,10 @@ describe("createdMessageQueueIndex", () => {
       .mockImplementationOnce(() =>
         Promise.resolve(right(aCreatedNotificationWithEmail))
       );
+
+    jest
+      .spyOn(MessageStatusModel.prototype, "upsert")
+      .mockReturnValue(Promise.resolve(right(none)));
 
     const profileSpy = jest
       .spyOn(ProfileModel.prototype, "findOneProfileByFiscalCode")
@@ -720,7 +725,7 @@ describe("processRuntimeError", () => {
     expect(winstonSpy).toHaveBeenCalledTimes(2);
   });
 
-  it.only("should retry on transient error", async () => {
+  it("should retry on transient error", async () => {
     const error = TransientError("err");
     const winstonSpy = jest.spyOn(winston, "warn");
     const messageStatusUpdaterMock = jest.fn().mockReturnValue(right(none));

--- a/lib/__tests__/created_message_queue_handler.test.ts
+++ b/lib/__tests__/created_message_queue_handler.test.ts
@@ -17,7 +17,7 @@ import { NewMessageWithContent } from "../models/message";
 
 import * as functionConfig from "../../CreatedMessageQueueHandler/function.json";
 
-import { isSome, none, some } from "fp-ts/lib/Option";
+import { none, some } from "fp-ts/lib/Option";
 import { FiscalCode } from "../api/definitions/FiscalCode";
 import { MessageBodyMarkdown } from "../api/definitions/MessageBodyMarkdown";
 
@@ -55,8 +55,7 @@ import {
   handleMessage,
   index,
   MESSAGE_QUEUE_NAME,
-  processRuntimeError,
-  processSuccess
+  processRuntimeError
 } from "../created_message_queue_handler";
 
 import { MessageStatusModel } from "../models/message_status";
@@ -708,41 +707,14 @@ describe("handleMessage", () => {
   });
 });
 
-describe("processSuccess", () => {
-  it("should enqueue notification to the email queue if an email is present", async () => {
-    const notification = aCreatedNotificationWithEmail;
-    const messageStatusUpdaterMock = jest.fn();
-
-    const result = await processSuccess(
-      notification as any,
-      aMessage,
-      aMessageEvent.senderMetadata
-    );
-
-    expect(messageStatusUpdaterMock).toHaveBeenCalledWith(
-      MessageStatusValueEnum.PROCESSED
-    );
-
-    expect(isRight(result)).toBeTruthy();
-    if (isRight(result)) {
-      expect(isSome(result.value)).toBeTruthy();
-      if (isSome(result.value)) {
-        expect(result.value.value).toEqual({
-          emailNotification: anEmailNotificationEvent
-        });
-      }
-    }
-  });
-});
-
 describe("processRuntimeError", () => {
   it("should retry on transient error", async () => {
     const error = TransientError("err");
     const winstonSpy = jest.spyOn(winston, "warn");
     const messageStatusUpdaterMock = jest.fn();
     await processRuntimeError(
-      messageStatusUpdaterMock,
       {} as any,
+      messageStatusUpdaterMock,
       error as any,
       {} as any
     );
@@ -756,8 +728,8 @@ describe("processRuntimeError", () => {
     const winstonSpy = jest.spyOn(winston, "error");
     const messageStatusUpdaterMock = jest.fn();
     await processRuntimeError(
-      messageStatusUpdaterMock,
       {} as any,
+      messageStatusUpdaterMock,
       error as any,
       {} as any
     );

--- a/lib/__tests__/created_message_queue_handler.test.ts
+++ b/lib/__tests__/created_message_queue_handler.test.ts
@@ -58,7 +58,7 @@ import {
   processRuntimeError,
   processSuccess
 } from "../created_message_queue_handler";
-import { processGenericError } from "../created_message_queue_handler";
+
 import { MessageStatusModel } from "../models/message_status";
 
 afterEach(() => {
@@ -714,8 +714,6 @@ describe("processSuccess", () => {
     const messageStatusUpdaterMock = jest.fn();
 
     const result = await processSuccess(
-      messageStatusUpdaterMock,
-      {} as any,
       notification as any,
       aMessage,
       aMessageEvent.senderMetadata
@@ -734,16 +732,6 @@ describe("processSuccess", () => {
         });
       }
     }
-  });
-});
-
-describe("processGenericError", () => {
-  it("should update message status to FAILED", async () => {
-    const messageStatusUpdaterMock = jest.fn();
-    await processGenericError(messageStatusUpdaterMock, new Error());
-    expect(messageStatusUpdaterMock).toHaveBeenCalledWith(
-      MessageStatusValueEnum.FAILED
-    );
   });
 });
 

--- a/lib/__tests__/emailnotifications_queue_handler.test.ts
+++ b/lib/__tests__/emailnotifications_queue_handler.test.ts
@@ -153,7 +153,7 @@ const aRetrievedNotificationStatus: RetrievedNotificationStatus = {
   notificationId: aNotificationId,
   status: NotificationChannelStatusValueEnum.SENT_TO_CHANNEL,
   statusId: makeStatusId(aNotificationId, NotificationChannelEnum.EMAIL),
-  updateAt: new Date(),
+  updatedAt: new Date(),
   version: 1 as NonNegativeNumber
 };
 

--- a/lib/__tests__/emailnotifications_queue_handler.test.ts
+++ b/lib/__tests__/emailnotifications_queue_handler.test.ts
@@ -25,7 +25,7 @@ import * as winston from "winston";
 
 import MockTransport = require("nodemailer-mock-transport");
 
-import { isNone, none, some } from "fp-ts/lib/Option";
+import { none, some } from "fp-ts/lib/Option";
 
 import { isLeft, isRight, left, right } from "fp-ts/lib/Either";
 import { EmailString, NonEmptyString } from "../utils/strings";
@@ -58,7 +58,7 @@ import { MessageContent } from "../api/definitions/MessageContent";
 import { NotificationChannelEnum } from "../api/definitions/NotificationChannel";
 import { NotificationChannelStatusValueEnum } from "../api/definitions/NotificationChannelStatusValue";
 import { TimeToLiveSeconds } from "../api/definitions/TimeToLiveSeconds";
-import { processSuccess } from "../emailnotifications_queue_handler";
+
 import {
   makeStatusId,
   NotificationStatusModel,
@@ -589,26 +589,6 @@ describe("emailnotificationQueueHandlerIndex", () => {
   });
 });
 
-describe("processSuccess", () => {
-  it("should update notification status to SENT_TO_CHANNEL", async () => {
-    const notificationStatusUpdaterMock = jest.fn();
-
-    const result = await processSuccess(
-      getMockNotificationEvent(),
-      notificationStatusUpdaterMock
-    );
-
-    expect(isRight(result)).toBeTruthy();
-    if (isRight(result)) {
-      expect(isNone(result.value)).toBeTruthy();
-    }
-
-    expect(notificationStatusUpdaterMock).toHaveBeenCalledWith(
-      NotificationChannelStatusValueEnum.SENT_TO_CHANNEL
-    );
-  });
-});
-
 describe("processRuntimeError", () => {
   it("should retry on transient error", async () => {
     const notificationStatusUpdaterMock = jest.fn();
@@ -639,18 +619,6 @@ describe("processRuntimeError", () => {
       NotificationChannelStatusValueEnum.FAILED
     );
     expect(updateMessageVisibilityTimeout).not.toHaveBeenCalled();
-    expect(winstonSpy).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("processGenericError", () => {
-  it("should update notification status to FAILED", async () => {
-    const notificationStatusUpdaterMock = jest.fn();
-    const winstonSpy = jest.spyOn(winston, "error");
-    await processGenericError(notificationStatusUpdaterMock, new Error());
-    expect(notificationStatusUpdaterMock).toHaveBeenCalledWith(
-      NotificationChannelStatusValueEnum.FAILED
-    );
     expect(winstonSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/__tests__/emailnotifications_queue_handler.test.ts
+++ b/lib/__tests__/emailnotifications_queue_handler.test.ts
@@ -150,7 +150,7 @@ const aRetrievedNotificationStatus: RetrievedNotificationStatus = {
   kind: "IRetrievedNotificationStatus",
   messageId: aMessageId,
   notificationId: aNotificationId,
-  status: NotificationChannelStatusValueEnum.SENT_TO_CHANNEL,
+  status: NotificationChannelStatusValueEnum.SENT,
   statusId: makeStatusId(aNotificationId, NotificationChannelEnum.EMAIL),
   updatedAt: new Date(),
   version: 1 as NonNegativeNumber

--- a/lib/__tests__/emailnotifications_queue_handler.test.ts
+++ b/lib/__tests__/emailnotifications_queue_handler.test.ts
@@ -37,7 +37,6 @@ import {
   generateDocumentHtml,
   handleNotification,
   index,
-  processGenericError,
   processRuntimeError,
   sendMail
 } from "../emailnotifications_queue_handler";

--- a/lib/__tests__/emailnotifications_queue_handler.test.ts
+++ b/lib/__tests__/emailnotifications_queue_handler.test.ts
@@ -547,18 +547,23 @@ describe("emailnotificationQueueHandlerIndex", () => {
       sendMail: jest.fn((_, cb) => cb(null, "ok"))
     });
 
-    jest
+    const statusSpy = jest
       .spyOn(NotificationStatusModel.prototype, "upsert")
       .mockReturnValue(Promise.resolve(right(none)));
 
     const winstonErrorSpy = jest.spyOn(winston, "error");
-    expect.assertions(2);
-    try {
-      await index(contextMock as any);
-    } catch (err) {
-      expect(err.kind).toEqual("TransientError");
-      expect(winstonErrorSpy).toHaveBeenCalledTimes(1);
-    }
+    const ret = await index(contextMock as any);
+    expect(ret).toEqual(undefined);
+    expect(statusSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: NotificationChannelStatusValueEnum.EXPIRED
+      }),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything()
+    );
+    expect(winstonErrorSpy).toHaveBeenCalledTimes(1);
   });
 
   it("should proceed on valid message payload", async () => {

--- a/lib/controllers/__tests__/messages.test.ts
+++ b/lib/controllers/__tests__/messages.test.ts
@@ -135,7 +135,7 @@ const aPublicExtendedMessage: CreatedMessageWithoutContent = {
 const aPublicExtendedMessageResponse: MessageResponseWithoutContent = {
   message: aPublicExtendedMessage,
   notification: {
-    email: NotificationChannelStatusValueEnum.SENT_TO_CHANNEL
+    email: NotificationChannelStatusValueEnum.SENT
   },
   status: MessageStatusValueEnum.ACCEPTED
 };
@@ -158,7 +158,7 @@ const aRetrievedNotificationStatus: RetrievedNotificationStatus = {
   kind: "IRetrievedNotificationStatus",
   messageId: "1" as NonEmptyString,
   notificationId: "1" as NonEmptyString,
-  status: NotificationChannelStatusValueEnum.SENT_TO_CHANNEL,
+  status: NotificationChannelStatusValueEnum.SENT,
   statusId: makeStatusId("1" as NonEmptyString, NotificationChannelEnum.EMAIL),
   updatedAt: new Date(),
   version: 1 as NonNegativeNumber

--- a/lib/controllers/__tests__/messages.test.ts
+++ b/lib/controllers/__tests__/messages.test.ts
@@ -197,7 +197,6 @@ describe("CreateMessageHandler", () => {
 
     const createMessageHandler = CreateMessageHandler(
       {} as any,
-      {} as any,
       mockMessageModel as any,
       {} as any
     );
@@ -237,7 +236,6 @@ describe("CreateMessageHandler", () => {
     const createMessageHandler = CreateMessageHandler(
       mockAppInsights as any,
       mockMessageModel as any,
-      getMessageStatusModelMock(),
       () => aMessageId
     );
 
@@ -319,7 +317,6 @@ describe("CreateMessageHandler", () => {
     const createMessageHandler = CreateMessageHandler(
       mockAppInsights as any,
       mockMessageModel as any,
-      getMessageStatusModelMock(),
       () => aMessageId
     );
 
@@ -411,7 +408,6 @@ describe("CreateMessageHandler", () => {
     const createMessageHandler = CreateMessageHandler(
       mockAppInsights as any,
       mockMessageModel as any,
-      getMessageStatusModelMock(),
       () => aMessageId
     );
 
@@ -502,7 +498,6 @@ describe("CreateMessageHandler", () => {
     const createMessageHandler = CreateMessageHandler(
       mockAppInsights as any,
       mockMessageModel as any,
-      getMessageStatusModelMock(),
       () => aMessageId
     );
 
@@ -598,7 +593,6 @@ describe("CreateMessageHandler", () => {
     const createMessageHandler = CreateMessageHandler(
       mockAppInsights as any,
       mockMessageModel as any,
-      getMessageStatusModelMock(),
       () => aMessageId
     );
 
@@ -648,7 +642,6 @@ describe("CreateMessageHandler", () => {
     const createMessageHandler = CreateMessageHandler(
       mockAppInsights as any,
       mockMessageModel as any,
-      getMessageStatusModelMock(),
       () => aMessageId
     );
 
@@ -688,7 +681,6 @@ describe("CreateMessageHandler", () => {
     const createMessageHandler = CreateMessageHandler(
       mockAppInsights as any,
       mockMessageModel as any,
-      getMessageStatusModelMock(),
       () => aMessageId
     );
 
@@ -1160,12 +1152,7 @@ describe("MessagePayloadMiddleware", () => {
 
 describe("CreateMessage", () => {
   it("should fail with 500 if context cannot be retrieved", async () => {
-    const createMessage = CreateMessage(
-      {} as any,
-      {} as any,
-      {} as any,
-      {} as any
-    );
+    const createMessage = CreateMessage({} as any, {} as any, {} as any);
     const mockResponse = MockResponse();
     const request = {
       app: {
@@ -1187,12 +1174,7 @@ describe("CreateMessage", () => {
     const headers: IHeaders = {
       "x-user-groups": ""
     };
-    const createMessage = CreateMessage(
-      {} as any,
-      {} as any,
-      {} as any,
-      {} as any
-    );
+    const createMessage = CreateMessage({} as any, {} as any, {} as any);
     const mockResponse = MockResponse();
     const request = {
       app: {
@@ -1217,12 +1199,7 @@ describe("CreateMessage", () => {
       "x-subscription-id": "someId",
       "x-user-groups": "ApiMessageWrite"
     };
-    const createMessage = CreateMessage(
-      {} as any,
-      {} as any,
-      {} as any,
-      {} as any
-    );
+    const createMessage = CreateMessage({} as any, {} as any, {} as any);
     const mockResponse = MockResponse();
     const request = {
       app: {

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -17,7 +17,7 @@ import { configureAzureContextTransport } from "./utils/logging";
 
 import * as documentDbUtils from "./utils/documentdb";
 
-import { fromNullable, isNone, none, Option } from "fp-ts/lib/Option";
+import { fromNullable, isNone, Option } from "fp-ts/lib/Option";
 
 import {
   BlobService,

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -103,6 +103,9 @@ const messageContainerName = getRequiredStringEnv("MESSAGE_CONTAINER_NAME");
 const storageConnectionString = getRequiredStringEnv("QueueStorageConnection");
 const queueConnectionString = getRequiredStringEnv("QueueStorageConnection");
 
+// We create the db client, services and models here
+// as if any error occurs during the construction of these objects
+// that would be unrecoverable anyway and we neither may trig a retry
 const documentClient = new DocumentDBClient(cosmosDbUri, {
   masterKey: cosmosDbKey
 });
@@ -112,7 +115,9 @@ const messageStatusModel = new MessageStatusModel(
   messageStatusCollectionUrl
 );
 
-// needed for retries
+// As we cannot use Functions bindings to do retries,
+// we resort to update the message visibility timeout
+// using the queue service (client for Azure queue storage)
 const queueService = createQueueService(queueConnectionString);
 
 const profileModel = new ProfileModel(documentClient, profilesCollectionUrl);

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -52,6 +52,7 @@ import {
 } from "./utils/azure_queues";
 import {
   isTransient,
+  of as RuntimeErrorOf,
   PermanentError,
   RuntimeError,
   TransientError
@@ -436,7 +437,7 @@ export async function index(
       queueService,
       messageStatusUpdater,
       context.bindingData,
-      error
+      RuntimeErrorOf(error)
     );
     if (shouldTriggerARetry) {
       throw TransientError(`CreatedMessageQueueHandler|Retry|${error.message}`);

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -288,15 +288,15 @@ export async function handleMessage(
 }
 
 /**
- * Returns left(true) in case the caller must
- * trigger a retry calling context.done(true)
+ * Returns true in case the caller must
+ * trigger a retry
  */
 export async function processRuntimeError(
   lQueueService: QueueService,
   messageStatusUpdater: MessageStatusUpdater,
   queueMessage: IQueueMessage,
   error: RuntimeError
-): Promise<Either<boolean, Option<OutputBindings>>> {
+): Promise<boolean> {
   if (isTransient(error)) {
     winston.warn(`CreatedMessageQueueHandler|Transient error|${error.message}`);
     const shouldTriggerARetry = await updateMessageVisibilityTimeout(
@@ -314,7 +314,7 @@ export async function processRuntimeError(
         }`
       );
     }
-    return left(shouldTriggerARetry);
+    return shouldTriggerARetry;
   } else {
     winston.error(
       `CreatedMessageQueueHandler|Permanent error|${error.message}`
@@ -333,8 +333,8 @@ export async function processRuntimeError(
         transientError
       );
     } else {
-      // return no bindings so message processing stops here
-      return right(none);
+      // message processing stops here
+      return false;
     }
   }
 }

--- a/lib/emailnotifications_queue_handler.ts
+++ b/lib/emailnotifications_queue_handler.ts
@@ -111,14 +111,6 @@ const queueService = createQueueService(queueConnectionString);
 
 const sendgridKey = getRequiredStringEnv("CUSTOMCONNSTR_SENDGRID_KEY");
 
-const mailerTransporter = NodeMailer.createTransport(
-  sendGridTransport({
-    auth: {
-      api_key: sendgridKey
-    }
-  })
-);
-
 //
 // options used when converting an HTML message to pure text
 // see https://www.npmjs.com/package/html-to-text#options
@@ -349,7 +341,7 @@ export async function processRuntimeError(
       queueMessage
     );
     const errorOrNotificationStatus = await notificationStatusUpdater(
-      NotificationChannelStatusValueEnum.QUEUED
+      NotificationChannelStatusValueEnum.THROTTLED
     );
     if (isLeft(errorOrNotificationStatus)) {
       winston.warn(
@@ -416,6 +408,14 @@ export async function index(
     return stopProcessing;
   }
   const emailNotificationEvent = errorOrNotificationEvent.value;
+
+  const mailerTransporter = NodeMailer.createTransport(
+    sendGridTransport({
+      auth: {
+        api_key: sendgridKey
+      }
+    })
+  );
 
   const notificationStatusUpdater = getNotificationStatusUpdater(
     notificationStatusModel,

--- a/lib/emailnotifications_queue_handler.ts
+++ b/lib/emailnotifications_queue_handler.ts
@@ -41,6 +41,7 @@ import { MessageSubject } from "./api/definitions/MessageSubject";
 import defaultEmailTemplate from "./templates/html/default";
 import {
   isTransient,
+  of as RuntimeErrorOf,
   PermanentError,
   RuntimeError,
   TransientError
@@ -474,7 +475,7 @@ export async function index(
       queueService,
       notificationStatusUpdater,
       context.bindingData,
-      error
+      RuntimeErrorOf(error)
     );
     if (shouldTriggerARetry) {
       throw TransientError(`EmailNotificationsHandler|Retry|${error.message}`);

--- a/lib/emailnotifications_queue_handler.ts
+++ b/lib/emailnotifications_queue_handler.ts
@@ -18,7 +18,7 @@ import { DocumentClient as DocumentDBClient } from "documentdb";
 import * as documentDbUtils from "./utils/documentdb";
 
 import { Either, isLeft, left, right } from "fp-ts/lib/Either";
-import { isNone, none, Option } from "fp-ts/lib/Option";
+import { isNone } from "fp-ts/lib/Option";
 import { getRequiredStringEnv } from "./utils/env";
 import { readableReport } from "./utils/validation_reporters";
 
@@ -330,7 +330,7 @@ export async function processRuntimeError(
   notificationStatusUpdater: NotificationStatusUpdater,
   queueMessage: IQueueMessage,
   error: RuntimeError
-): Promise<Either<boolean, Option<OutputBindings>>> {
+): Promise<boolean> {
   if (isTransient(error)) {
     winston.warn(
       `EmailNotificationQueueHandler|Transient error|${error.message}`
@@ -350,7 +350,7 @@ export async function processRuntimeError(
         }`
       );
     }
-    return left(shouldTriggerARetry);
+    return shouldTriggerARetry;
   } else {
     winston.error(
       `EmailNotificationQueueHandler|Permanent error|${error.message}`
@@ -370,7 +370,7 @@ export async function processRuntimeError(
       );
     } else {
       // return no bindings so message processing stops here
-      return right(none);
+      return false;
     }
   }
 }

--- a/lib/models/__tests__/message.test.ts
+++ b/lib/models/__tests__/message.test.ts
@@ -96,7 +96,10 @@ describe("createMessage", () => {
 
     expect(isRight(result)).toBeTruthy();
     if (isRight(result)) {
-      expect(result.value).toEqual(aRetrievedMessageWithContent);
+      expect(result.value).toEqual({
+        ...aRetrievedMessageWithContent,
+        createdAt: expect.any(Date)
+      });
     }
   });
 

--- a/lib/models/__tests__/message_status.test.ts
+++ b/lib/models/__tests__/message_status.test.ts
@@ -1,0 +1,252 @@
+// tslint:disable:no-any
+
+import { isLeft, isRight } from "fp-ts/lib/Either";
+import { isSome } from "fp-ts/lib/Option";
+
+import * as DocumentDb from "documentdb";
+
+import * as DocumentDbUtils from "../../utils/documentdb";
+import { NonNegativeNumber } from "../../utils/numbers";
+import { NonEmptyString } from "../../utils/strings";
+
+import { MessageStatusValueEnum } from "../../api/definitions/MessageStatusValue";
+import { readableReport } from "../../utils/validation_reporters";
+import {
+  MESSAGE_STATUS_COLLECTION_NAME,
+  MessageStatus,
+  MessageStatusModel,
+  RetrievedMessageStatus
+} from "../message_status";
+
+const aDatabaseUri = DocumentDbUtils.getDatabaseUri("mockdb" as NonEmptyString);
+const collectionUrl = DocumentDbUtils.getCollectionUri(
+  aDatabaseUri,
+  MESSAGE_STATUS_COLLECTION_NAME
+);
+
+const aMessageId = "A_MESSAGE_ID" as NonEmptyString;
+
+const aSerializedMessageStatus = {
+  messageId: aMessageId,
+  status: MessageStatusValueEnum.ACCEPTED,
+  updatedAt: new Date().toISOString()
+};
+
+const aMessageStatus = MessageStatus.decode(
+  aSerializedMessageStatus
+).getOrElseL(errs => {
+  const error = readableReport(errs);
+  throw new Error("Fix MessageStatus mock: " + error);
+});
+
+const aSerializedRetrievedMessageStatus = {
+  _self: "_self",
+  _ts: 1,
+  ...aSerializedMessageStatus,
+  id: `${aMessageId}-${"0".repeat(16)}` as NonEmptyString,
+  kind: "IRetrievedMessageStatus",
+  version: 0 as NonNegativeNumber
+};
+
+const aRetrievedMessageStatus = RetrievedMessageStatus.decode(
+  aSerializedRetrievedMessageStatus
+).getOrElseL(errs => {
+  const error = readableReport(errs);
+  throw new Error("Fix MessageStatus mock: " + error);
+});
+
+describe("findOneMessageStatusById", () => {
+  it("should resolve a promise to an existing Message status", async () => {
+    const iteratorMock = {
+      executeNext: jest.fn(cb =>
+        cb(undefined, [aSerializedRetrievedMessageStatus], undefined)
+      )
+    };
+
+    const clientMock = {
+      queryDocuments: jest.fn((__, ___) => iteratorMock)
+    };
+
+    const model = new MessageStatusModel(
+      (clientMock as any) as DocumentDb.DocumentClient,
+      collectionUrl
+    );
+
+    const result = await model.findOneByMessageId(aMessageId);
+
+    expect(isRight(result)).toBeTruthy();
+    if (isRight(result)) {
+      expect(result.value.isSome()).toBeTruthy();
+      expect(result.value.toUndefined()).toEqual(aRetrievedMessageStatus);
+    }
+  });
+
+  it("should resolve a promise to an empty value if no MessageStatus is found", async () => {
+    const iteratorMock = {
+      executeNext: jest.fn(cb => cb(undefined, [], undefined))
+    };
+
+    const clientMock = {
+      queryDocuments: jest.fn((__, ___) => iteratorMock)
+    };
+
+    const model = new MessageStatusModel(
+      (clientMock as any) as DocumentDb.DocumentClient,
+      collectionUrl
+    );
+
+    const result = await model.findOneByMessageId(aMessageId);
+
+    expect(isRight(result)).toBeTruthy();
+    if (isRight(result)) {
+      expect(result.value.isNone()).toBeTruthy();
+    }
+  });
+});
+
+describe("createMessageStatus", () => {
+  it("should create a new MessageStatus", async () => {
+    const clientMock: any = {
+      createDocument: jest.fn((_, __, ___, cb) => {
+        cb(undefined, aSerializedRetrievedMessageStatus);
+      })
+    };
+
+    const model = new MessageStatusModel(clientMock, collectionUrl);
+
+    const result = await model.create(aMessageStatus, aMessageStatus.messageId);
+
+    expect(clientMock.createDocument).toHaveBeenCalledTimes(1);
+    expect(clientMock.createDocument.mock.calls[0][1].kind).toBeUndefined();
+    expect(clientMock.createDocument.mock.calls[0][2]).toHaveProperty(
+      "partitionKey",
+      aMessageStatus.messageId
+    );
+    expect(isRight(result)).toBeTruthy();
+    if (isRight(result)) {
+      expect(result.value.messageId).toEqual(aMessageStatus.messageId);
+      expect(result.value.id).toEqual(`${aMessageId}-${"0".repeat(16)}`);
+      expect(result.value.version).toEqual(0);
+    }
+  });
+
+  it("should resolve the promise to an error value in case of a query error", async () => {
+    const clientMock: any = {
+      createDocument: jest.fn((_, __, ___, cb) => {
+        cb("error");
+      })
+    };
+
+    const model = new MessageStatusModel(clientMock, collectionUrl);
+
+    const result = await model.create(
+      aMessageStatus,
+      aSerializedMessageStatus.messageId
+    );
+
+    expect(clientMock.createDocument).toHaveBeenCalledTimes(1);
+
+    expect(isLeft(result)).toBeTruthy();
+    if (isLeft(result)) {
+      expect(result.value).toEqual("error");
+    }
+  });
+});
+
+describe("updateMessageStatus", () => {
+  it("should update an existing MessageStatus", async () => {
+    const clientMock: any = {
+      createDocument: jest.fn((_, newDocument, ___, cb) => {
+        const retrievedDocument = RetrievedMessageStatus.encode(newDocument);
+        cb(undefined, { ...retrievedDocument, _self: "_self", _ts: 1 });
+      }),
+      readDocument: jest.fn((_, __, cb) =>
+        cb(undefined, aSerializedRetrievedMessageStatus)
+      )
+    };
+
+    const model = new MessageStatusModel(clientMock, collectionUrl);
+
+    const result = await model.update(
+      aRetrievedMessageStatus.id,
+      aRetrievedMessageStatus.messageId,
+      p => {
+        return {
+          ...p
+        };
+      }
+    );
+
+    expect(clientMock.createDocument).toHaveBeenCalledTimes(1);
+    expect(clientMock.createDocument.mock.calls[0][1].kind).toBeUndefined();
+    expect(clientMock.createDocument.mock.calls[0][2]).toHaveProperty(
+      "partitionKey",
+      aRetrievedMessageStatus.messageId
+    );
+    expect(isRight(result)).toBeTruthy();
+    if (isRight(result)) {
+      expect(result.value.isSome()).toBeTruthy();
+      if (isSome(result.value)) {
+        const updatedMessageStatus = result.value.value;
+        expect(updatedMessageStatus.messageId).toEqual(
+          aRetrievedMessageStatus.messageId
+        );
+        expect(updatedMessageStatus.id).toEqual(
+          `${aMessageId}-${"0".repeat(15)}1`
+        );
+        expect(updatedMessageStatus.version).toEqual(1);
+        expect(updatedMessageStatus.status).toEqual(
+          aRetrievedMessageStatus.status
+        );
+      }
+    }
+  });
+
+  it("should resolve the promise to an error value in case of a readDocument error", async () => {
+    const clientMock: any = {
+      createDocument: jest.fn(),
+      readDocument: jest.fn((_, __, cb) => cb("error"))
+    };
+
+    const model = new MessageStatusModel(clientMock, collectionUrl);
+
+    const result = await model.update(
+      aRetrievedMessageStatus.id,
+      aRetrievedMessageStatus.messageId,
+      o => o
+    );
+
+    expect(clientMock.readDocument).toHaveBeenCalledTimes(1);
+    expect(clientMock.createDocument).not.toHaveBeenCalled();
+
+    expect(isLeft(result)).toBeTruthy();
+    if (isLeft(result)) {
+      expect(result.value).toEqual("error");
+    }
+  });
+
+  it("should resolve the promise to an error value in case of a createDocument error", async () => {
+    const clientMock: any = {
+      createDocument: jest.fn((_, __, ___, cb) => cb("error")),
+      readDocument: jest.fn((_, __, cb) =>
+        cb(undefined, aSerializedRetrievedMessageStatus)
+      )
+    };
+
+    const model = new MessageStatusModel(clientMock, collectionUrl);
+
+    const result = await model.update(
+      aRetrievedMessageStatus.id,
+      aRetrievedMessageStatus.messageId,
+      o => o
+    );
+
+    expect(clientMock.readDocument).toHaveBeenCalledTimes(1);
+    expect(clientMock.createDocument).toHaveBeenCalledTimes(1);
+
+    expect(isLeft(result)).toBeTruthy();
+    if (isLeft(result)) {
+      expect(result.value).toEqual("error");
+    }
+  });
+});

--- a/lib/models/__tests__/notification_status.test.ts
+++ b/lib/models/__tests__/notification_status.test.ts
@@ -33,7 +33,7 @@ const aSerializedNotificationStatus = {
   notificationId: "A_NOTIFICATION_ID" as NonEmptyString,
   status: NotificationChannelStatusValueEnum.SENT_TO_CHANNEL,
   statusId: aNotificationStatusId,
-  updateAt: new Date().toISOString()
+  updatedAt: new Date().toISOString()
 };
 
 const aNotificationStatus = NotificationStatus.decode(

--- a/lib/models/__tests__/notification_status.test.ts
+++ b/lib/models/__tests__/notification_status.test.ts
@@ -31,7 +31,7 @@ const aSerializedNotificationStatus = {
   channel: NotificationChannelEnum.EMAIL,
   messageId: "A_MESSAGE_ID" as NonEmptyString,
   notificationId: "A_NOTIFICATION_ID" as NonEmptyString,
-  status: NotificationChannelStatusValueEnum.SENT_TO_CHANNEL,
+  status: NotificationChannelStatusValueEnum.SENT,
   statusId: aNotificationStatusId,
   updatedAt: new Date().toISOString()
 };

--- a/lib/models/message_status.ts
+++ b/lib/models/message_status.ts
@@ -1,0 +1,170 @@
+import * as t from "io-ts";
+
+import { pick, tag } from "../utils/types";
+
+import * as DocumentDb from "documentdb";
+import * as DocumentDbUtils from "../utils/documentdb";
+import {
+  DocumentDbModelVersioned,
+  ModelId,
+  VersionedModel
+} from "../utils/documentdb_model_versioned";
+
+import { Either } from "fp-ts/lib/Either";
+
+import {
+  MessageStatusValue,
+  MessageStatusValueEnum
+} from "../api/definitions/MessageStatusValue";
+import { Timestamp } from "../api/definitions/Timestamp";
+
+import { Option } from "fp-ts/lib/Option";
+import { nonEmptyStringToModelId } from "../utils/conversions";
+import { RuntimeError, TransientError } from "../utils/errors";
+import { NonNegativeNumber } from "../utils/numbers";
+import { NonEmptyString } from "../utils/strings";
+
+export const MESSAGE_STATUS_COLLECTION_NAME = "message-status";
+export const MESSAGE_STATUS_MODEL_ID_FIELD = "messageId";
+export const MESSAGE_STATUS_MODEL_PK_FIELD = "messageId";
+
+// We cannot intersect with MessageStatus
+// as it is a *strict* interface
+export const MessageStatus = t.interface({
+  messageId: NonEmptyString,
+  status: MessageStatusValue,
+  updatedAt: Timestamp
+});
+
+export type MessageStatus = t.TypeOf<typeof MessageStatus>;
+
+/**
+ * Interface for new MessageStatus objects
+ */
+
+interface INewMessageStatusTag {
+  readonly kind: "INewMessageStatus";
+}
+
+export const NewMessageStatus = tag<INewMessageStatusTag>()(
+  t.intersection([MessageStatus, DocumentDbUtils.NewDocument, VersionedModel])
+);
+
+export type NewMessageStatus = t.TypeOf<typeof NewMessageStatus>;
+
+/**
+ * Interface for retrieved MessageStatus objects
+ *
+ * Existing MessageStatus records have a version number.
+ */
+interface IRetrievedMessageStatusTag {
+  readonly kind: "IRetrievedMessageStatus";
+}
+
+export const RetrievedMessageStatus = tag<IRetrievedMessageStatusTag>()(
+  t.intersection([
+    MessageStatus,
+    DocumentDbUtils.RetrievedDocument,
+    VersionedModel
+  ])
+);
+
+export type RetrievedMessageStatus = t.TypeOf<typeof RetrievedMessageStatus>;
+
+function toRetrieved(
+  result: DocumentDb.RetrievedDocument
+): RetrievedMessageStatus {
+  return RetrievedMessageStatus.decode(result).getOrElseL(_ => {
+    throw new Error("Fatal, result is not a valid RetrievedMessageStatus");
+  });
+}
+
+function getModelId(o: MessageStatus): ModelId {
+  return nonEmptyStringToModelId(o.messageId);
+}
+
+function updateModelId(
+  o: MessageStatus,
+  id: NonEmptyString,
+  version: NonNegativeNumber
+): NewMessageStatus {
+  return {
+    ...o,
+    id,
+    kind: "INewMessageStatus",
+    version
+  };
+}
+
+function toBaseType(o: RetrievedMessageStatus): MessageStatus {
+  return pick(["messageId", "status", "updatedAt"], o);
+}
+
+export type MessageStatusUpdater = ((
+  status: MessageStatusValueEnum
+) => Promise<Either<RuntimeError, RetrievedMessageStatus>>);
+
+/**
+ * Convenience method that returns a function
+ * to update the Message status.
+ */
+export const getMessageStatusUpdater = (
+  messageStatusModel: MessageStatusModel,
+  messageId: NonEmptyString
+): MessageStatusUpdater => {
+  return async status => {
+    return await messageStatusModel
+      .upsert(
+        {
+          messageId,
+          status,
+          updatedAt: new Date()
+        },
+        MESSAGE_STATUS_MODEL_ID_FIELD,
+        messageId,
+        MESSAGE_STATUS_MODEL_PK_FIELD,
+        messageId
+      )
+      .then(errorOrResult =>
+        errorOrResult.mapLeft(err => TransientError(err.body))
+      );
+  };
+};
+
+/**
+ * A model for handling MessageStatus
+ */
+export class MessageStatusModel extends DocumentDbModelVersioned<
+  MessageStatus,
+  NewMessageStatus,
+  RetrievedMessageStatus
+> {
+  /**
+   * Creates a new MessageStatus model
+   *
+   * @param dbClient the DocumentDB client
+   * @param collectionUrl the collection URL
+   */
+  constructor(
+    dbClient: DocumentDb.DocumentClient,
+    collectionUrl: DocumentDbUtils.IDocumentDbCollectionUri
+  ) {
+    super(
+      dbClient,
+      collectionUrl,
+      toBaseType,
+      toRetrieved,
+      getModelId,
+      updateModelId
+    );
+  }
+
+  public findOneByMessageId(
+    messageId: NonEmptyString
+  ): Promise<Either<DocumentDb.QueryError, Option<RetrievedMessageStatus>>> {
+    return super.findLastVersionByModelId(
+      MESSAGE_STATUS_MODEL_ID_FIELD,
+      messageId
+    );
+  }
+}

--- a/lib/models/notification_status.ts
+++ b/lib/models/notification_status.ts
@@ -47,7 +47,7 @@ export const NotificationStatus = t.interface({
   // As we have one NotificationStatus for each channel
   // of a Notification => statusId = notificationId + channelName
   statusId: NotificationStatusId,
-  updateAt: Timestamp
+  updatedAt: Timestamp
 });
 
 export type NotificationStatus = t.TypeOf<typeof NotificationStatus>;
@@ -139,7 +139,7 @@ function toBaseType(o: RetrievedNotificationStatus): NotificationStatus {
       "notificationId",
       "status",
       "statusId",
-      "updateAt"
+      "updatedAt"
     ],
     o
   );
@@ -147,7 +147,7 @@ function toBaseType(o: RetrievedNotificationStatus): NotificationStatus {
 
 export type NotificationStatusUpdater = ((
   status: NotificationChannelStatusValueEnum
-) => Promise<Either<RuntimeError, NotificationStatus>>);
+) => Promise<Either<RuntimeError, RetrievedNotificationStatus>>);
 
 /**
  * Convenience method that returns a function to update the notification status
@@ -169,7 +169,7 @@ export const getNotificationStatusUpdater = (
           notificationId,
           status,
           statusId,
-          updateAt: new Date()
+          updatedAt: new Date()
         },
         NOTIFICATION_STATUS_MODEL_ID_FIELD,
         statusId,

--- a/lib/public_api_v1.ts
+++ b/lib/public_api_v1.ts
@@ -33,7 +33,12 @@ import * as express from "express";
 import { secureExpressApp } from "./utils/express";
 
 import { createBlobService } from "azure-storage";
+
 import { GetService } from "./controllers/services";
+import {
+  MESSAGE_STATUS_COLLECTION_NAME,
+  MessageStatusModel
+} from "./models/message_status";
 import {
   NOTIFICATION_STATUS_COLLECTION_NAME,
   NotificationStatusModel
@@ -57,6 +62,10 @@ const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
 const messagesCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,
   "messages"
+);
+const messageStatusCollectionUrl = documentDbUtils.getCollectionUri(
+  documentDbDatabaseUrl,
+  MESSAGE_STATUS_COLLECTION_NAME
 );
 const profilesCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,
@@ -84,6 +93,10 @@ const messageModel = new MessageModel(
   documentClient,
   messagesCollectionUrl,
   messageContainerName
+);
+const messageStatusModel = new MessageStatusModel(
+  documentClient,
+  messageStatusCollectionUrl
 );
 const serviceModel = new ServiceModel(documentClient, servicesCollectionUrl);
 const notificationModel = new NotificationModel(
@@ -122,6 +135,7 @@ app.get(
   GetMessage(
     serviceModel,
     messageModel,
+    messageStatusModel,
     notificationModel,
     notificationStatusModel,
     blobService

--- a/lib/utils/errors.ts
+++ b/lib/utils/errors.ts
@@ -40,11 +40,15 @@ export const UnknowError = RuntimeError(ErrorTypes.UnknowError);
  * Useful in try / catch blocks where the object caught is untyped.
  */
 // tslint:disable-next-line:no-any
-export const of = (error: any) =>
-  UnknowError(
-    error && error.message ? error.message : JSON.stringify(error),
-    error instanceof Error ? error : undefined
-  );
+export const of = (error: any): RuntimeError =>
+  error && ErrorTypes.hasOwnProperty(error.kind)
+    ? error
+    : UnknowError(
+        error instanceof Error && error.message
+          ? error.message
+          : JSON.stringify(error),
+        error instanceof Error ? error : undefined
+      );
 
 export type RuntimeError = TransientError | PermanentError | UnknowError;
 

--- a/lib/utils/errors.ts
+++ b/lib/utils/errors.ts
@@ -6,7 +6,8 @@
 
 export const enum ErrorTypes {
   TransientError = "TransientError",
-  PermanentError = "PermanentError"
+  PermanentError = "PermanentError",
+  UnknowError = "UnknowError"
 }
 
 interface IRuntimeError<T extends ErrorTypes> {
@@ -31,7 +32,21 @@ export const TransientError = RuntimeError(ErrorTypes.TransientError);
 export type PermanentError = IRuntimeError<ErrorTypes.PermanentError>;
 export const PermanentError = RuntimeError(ErrorTypes.PermanentError);
 
-export type RuntimeError = TransientError | PermanentError;
+export type UnknowError = IRuntimeError<ErrorTypes.UnknowError>;
+export const UnknowError = RuntimeError(ErrorTypes.UnknowError);
+
+/**
+ * Construct a RuntimeError from an object.
+ * Useful in try / catch blocks where the object caught is untyped.
+ */
+// tslint:disable-next-line:no-any
+export const of = (error: any) =>
+  UnknowError(
+    error && error.message ? error.message : JSON.stringify(error),
+    error instanceof Error ? error : undefined
+  );
+
+export type RuntimeError = TransientError | PermanentError | UnknowError;
 
 // tslint:disable-next-line:no-any
 export const isTransient = (error: any): error is TransientError =>


### PR DESCRIPTION
- added versioned message status model
- update message status in the message queue handler
- the getmessage controller now returns message status aside notification status

Shape of a message:

```
{
    "message": {
        "content": {
            "markdown": "...",
            "subject": "..."
        },
        "fiscal_code": "ZERTHB99A45Y149X",
        "id": "01C8RHV61QBX82GSWYQ1VFNBN5",
        "sender_service_id": "5a25"
    },
    "notification": {
        "email": "SENT_TO_CHANNEL"
    },
    "status": "PROCESSED" <------
}

```
