### PR TITLE
[#155970981] fix wait for promises in tests

### DIFF
--- a/lib/controllers/__tests__/messages.test.ts
+++ b/lib/controllers/__tests__/messages.test.ts
@@ -56,6 +56,10 @@ import {
   MessagePayloadMiddleware
 } from "../messages";
 
+function flushPromises<T>(): Promise<T> {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
 afterEach(() => {
   jest.resetAllMocks();
   jest.restoreAllMocks();
@@ -1154,16 +1158,22 @@ describe("MessagePayloadMiddleware", () => {
 
 describe("CreateMessage", () => {
   it("should fail with 500 if context cannot be retrieved", async () => {
+    const headers: IHeaders = {
+      "x-subscription-id": "someId",
+      "x-user-groups": "ApiMessageWrite"
+    };
     const createMessage = CreateMessage({} as any, {} as any, {} as any);
     const mockResponse = MockResponse();
     const request = {
       app: {
         get: jest.fn(() => undefined)
       },
-      body: {}
+      body: {},
+      header: jest.fn(lookup(headers)),
+      params: { fiscalcode: "x" }
     };
     createMessage(request as any, mockResponse, _ => _);
-    await Promise.resolve({});
+    await flushPromises();
     expect(request.app.get).toHaveBeenCalledWith("context");
     expect(mockResponse.set).toHaveBeenCalledWith(
       "Content-Type",
@@ -1185,10 +1195,11 @@ describe("CreateMessage", () => {
         })
       },
       body: {},
-      header: jest.fn(lookup(headers))
+      header: jest.fn(lookup(headers)),
+      params: { fiscalcode: "x" }
     };
     createMessage(request as any, mockResponse, _ => _);
-    await Promise.resolve({});
+    await flushPromises();
     expect(mockResponse.set).toHaveBeenCalledWith(
       "Content-Type",
       "application/problem+json"
@@ -1210,10 +1221,11 @@ describe("CreateMessage", () => {
         })
       },
       body: {},
-      header: jest.fn(lookup(headers))
+      header: jest.fn(lookup(headers)),
+      params: { fiscalcode: "x" }
     };
     createMessage(request as any, mockResponse, _ => _);
-    await Promise.resolve({});
+    await flushPromises();
     expect(mockResponse.set).toHaveBeenCalledWith(
       "Content-Type",
       "application/problem+json"

--- a/lib/controllers/__tests__/messages.test.ts
+++ b/lib/controllers/__tests__/messages.test.ts
@@ -56,10 +56,6 @@ import {
   MessagePayloadMiddleware
 } from "../messages";
 
-function flushPromises<T>(): Promise<T> {
-  return new Promise(resolve => setImmediate(resolve));
-}
-
 afterEach(() => {
   jest.resetAllMocks();
   jest.restoreAllMocks();
@@ -1172,8 +1168,7 @@ describe("CreateMessage", () => {
       header: jest.fn(lookup(headers)),
       params: { fiscalcode: "x" }
     };
-    createMessage(request as any, mockResponse, _ => _);
-    await flushPromises();
+    await createMessage(request as any, mockResponse, _ => _);
     expect(request.app.get).toHaveBeenCalledWith("context");
     expect(mockResponse.set).toHaveBeenCalledWith(
       "Content-Type",
@@ -1198,8 +1193,7 @@ describe("CreateMessage", () => {
       header: jest.fn(lookup(headers)),
       params: { fiscalcode: "x" }
     };
-    createMessage(request as any, mockResponse, _ => _);
-    await flushPromises();
+    await createMessage(request as any, mockResponse, _ => _);
     expect(mockResponse.set).toHaveBeenCalledWith(
       "Content-Type",
       "application/problem+json"
@@ -1224,8 +1218,7 @@ describe("CreateMessage", () => {
       header: jest.fn(lookup(headers)),
       params: { fiscalcode: "x" }
     };
-    createMessage(request as any, mockResponse, _ => _);
-    await flushPromises();
+    await createMessage(request as any, mockResponse, _ => _);
     expect(mockResponse.set).toHaveBeenCalledWith(
       "Content-Type",
       "application/problem+json"

--- a/lib/utils/request_middleware.ts
+++ b/lib/utils/request_middleware.ts
@@ -18,7 +18,7 @@ export function wrapRequestHandler<R>(
   handler: RequestHandler<R>
 ): express.RequestHandler {
   return (request, response, _) => {
-    handler(request).then(
+    return handler(request).then(
       r => {
         r.apply(response);
         winston.log(


### PR DESCRIPTION
Actually there's a bug in promise handling (tests do not await). 
This PR fixes this beahvior. Now the express request handler returns the promise so we can wait in tests.