### PR TITLE
[#156379054] fix funcpack build with custom webpack config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/coverage
 **/*.js
 !gulpfile.js
+!webpack.config.js
 **/*.log
 **/local.*
 **/*.js.map

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,7 +123,9 @@ gulp.task("test", cb => runSequence("yarn:lint", "unit:test", cb));
  * Package Azure Functions code and dependencines in a single file
  */
 gulp.task("yarn:funcpack", () => {
-  return gulp.src(TYPESCRIPT_SOURCE_DIR).pipe(run("yarn run funcpack pack ./"));
+  return gulp
+    .src(TYPESCRIPT_SOURCE_DIR)
+    .pipe(run("yarn run funcpack pack -e webpack.config.js ./"));
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/prettier": "^1.6.1",
     "@types/swagger-parser": "^4.0.2",
     "@types/swagger-schema-official": "^2.0.6",
-    "azure-functions-pack": "^0.3.1",
+    "azure-functions-pack": "^1.0.0",
     "danger": "^3.1.7",
     "danger-plugin-digitalcitizenship": "https://github.com/teamdigitale/danger-plugin-digitalcitizenship#v0.0.4",
     "gulp": "^3.9.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,10 @@
+/**
+ * Decorates the default webpack configuration (coming from funcpack).
+ * See https://github.com/Azure/azure-functions-pack
+ */
+module.exports = function(config, webpack) {
+  // fix an error with npm modules that call GENTLY.hijack(require)
+  // ie. formidable needed by superagent
+  config.plugins.push(new webpack.DefinePlugin({ "global.GENTLY": false }));
+  return config;
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@
 module.exports = function(config, webpack) {
   // fix an error with npm modules that call GENTLY.hijack(require)
   // ie. formidable needed by superagent
+  // see https://github.com/felixge/node-formidable/issues/337
   config.plugins.push(new webpack.DefinePlugin({ "global.GENTLY": false }));
   return config;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -502,12 +502,14 @@ azure-function-express@^1.2.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/azure-function-express/-/azure-function-express-1.3.0.tgz#8c5e04cd0f195dd3f5281f4cfe3b1854d215aad0"
 
-azure-functions-pack@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/azure-functions-pack/-/azure-functions-pack-0.3.1.tgz#7aa6c6315543814b749255d6f54debc7a2f0599e"
+azure-functions-pack@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/azure-functions-pack/-/azure-functions-pack-1.0.0.tgz#0a14ee49340db63748bef973b934d45f2834fc2b"
   dependencies:
     commander "~2.9.0"
     debug "~2.6.1"
+    mkdirp "^0.5.1"
+    ncp "^2.0.0"
     rimraf "~2.5.4"
     webpack "~3.5.6"
     winston "~2.3.1"
@@ -5044,6 +5046,10 @@ ncname@1.0.x:
   resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"
   dependencies:
     xml-char-classes "^1.0.0"
+
+ncp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
 
 negotiator@0.6.1:
   version "0.6.1"


### PR DESCRIPTION
the actual build fails with 

`Exception while executing function: Functions.AdminApi -> One or more errors occurred. -> TypeError: require is not a function\n`

this fixes an error with funcpack + modules that "gently" hijacks require, see
https://github.com/felixge/node-formidable/issues/337
