### PR TITLE
[#157284546] expose message creation date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format of this file is loosely based on [Keep a Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Added
+- [getMessage] Added `created_at` field in returned message payload 
+
 ## [v0.38.0] - 2018-05-04
 
 ### Added

--- a/api/definitions.yaml
+++ b/api/definitions.yaml
@@ -124,12 +124,17 @@ CreatedMessageWithContent:
       $ref: "#/FiscalCode"
     time_to_live:
       $ref: "#/TimeToLiveSeconds"
+    created_at:
+      $ref: "#/Timestamp"
     content:
       $ref: "#/MessageContent"
     sender_service_id:
       type: string
   required:
+    - id
     - fiscal_code
+    - created_at
+    - content
     - sender_service_id
 CreatedMessageWithoutContent:
   type: object
@@ -140,10 +145,14 @@ CreatedMessageWithoutContent:
       $ref: "#/FiscalCode"
     time_to_live:
       $ref: "#/TimeToLiveSeconds"
+    created_at:
+      $ref: "#/Timestamp"
     sender_service_id:
       type: string
   required:
+    - id
     - fiscal_code
+    - created_at
     - sender_service_id
 MessageResponseNotificationStatus:
   type: object

--- a/lib/controllers/__tests__/messages.test.ts
+++ b/lib/controllers/__tests__/messages.test.ts
@@ -129,6 +129,7 @@ const aRetrievedMessageWithoutContent: RetrievedMessageWithoutContent = {
 };
 
 const aPublicExtendedMessage: CreatedMessageWithoutContent = {
+  created_at: new Date(),
   fiscal_code: aNewMessageWithoutContent.fiscalCode,
   id: "A_MESSAGE_ID",
   sender_service_id: aNewMessageWithoutContent.senderServiceId

--- a/lib/controllers/messages.ts
+++ b/lib/controllers/messages.ts
@@ -99,6 +99,7 @@ import {
 } from "fp-ts/lib/Option";
 
 import { CreatedMessageWithContent } from "../api/definitions/CreatedMessageWithContent";
+import { MessageResponseWithoutContent } from "../api/definitions/MessageResponseWithoutContent";
 import { MessageStatusValueEnum } from "../api/definitions/MessageStatusValue";
 import { NotificationChannelEnum } from "../api/definitions/NotificationChannel";
 import { NotificationChannelStatusValueEnum } from "../api/definitions/NotificationChannelStatusValue";
@@ -145,6 +146,7 @@ function retrievedMessageToPublic(
   retrievedMessage: RetrievedMessage
 ): CreatedMessageWithoutContent {
   return {
+    created_at: retrievedMessage.createdAt,
     fiscal_code: retrievedMessage.fiscalCode,
     id: retrievedMessage.id,
     sender_service_id: retrievedMessage.senderServiceId
@@ -190,7 +192,9 @@ type IGetMessageHandler = (
   fiscalCode: FiscalCode,
   messageId: string
 ) => Promise<
-  | IResponseSuccessJson<MessageResponseWithContent>
+  | IResponseSuccessJson<
+      MessageResponseWithContent | MessageResponseWithoutContent
+    >
   | IResponseErrorNotFound
   | IResponseErrorQuery
   | IResponseErrorValidation
@@ -586,7 +590,9 @@ export function GetMessageHandler(
       );
     }
 
-    const message: CreatedMessageWithContent = withoutUndefinedValues({
+    const message:
+      | CreatedMessageWithContent
+      | CreatedMessageWithoutContent = withoutUndefinedValues({
       content: errorOrMaybeContent.value.toUndefined(),
       ...retrievedMessageToPublic(retrievedMessage)
     });
@@ -619,7 +625,9 @@ export function GetMessageHandler(
     }
     const maybeMessageStatus = errorOrMaybeMessageStatus.value;
 
-    const returnedMessage: MessageResponseWithContent = {
+    const returnedMessage:
+      | MessageResponseWithContent
+      | MessageResponseWithoutContent = {
       message,
       notification: notificationStatuses.toUndefined(),
       // we do not return the status date-time


### PR DESCRIPTION
- Exposes "created_at" with message payload in GetMessage(s) controllers
- Fix some required fields in API definitions