### PR TITLE
[#157387718] WIP: service blacklist

### DIFF
--- a/api/definitions.yaml
+++ b/api/definitions.yaml
@@ -32,10 +32,22 @@ ProblemJson:
         It may or may not yield further information if dereferenced.
 NotificationChannel:
   type: string
+  description: |-
+    All notification channels.
   x-extensible-enum:
     - EMAIL
     - WEBHOOK
   example: EMAIL
+MessageChannel:
+  type: string
+  description: |-
+    All notification channels plus the message inbox.
+    These represent all the possible channels a user could block.
+  x-extensible-enum:
+    - EMAIL
+    - INBOX
+    - WEBHOOK
+  example: INBOX
 NotificationChannelStatusValue:
   type: string
   description: |-
@@ -226,6 +238,23 @@ PaginationResponse:
         retrieved collection of items.
       format: uri
       example: https://example.com/?p=0XXX2
+BlockedChannel:
+  description: |-
+    A notification channel (ie. email) blocked by the user.
+    The channel is related to a specific service (sender).
+  type: object
+  properties:
+    service_id:
+      $ref: "#/ServiceId"
+BlockedChannels:
+  type: object
+  additionalProperties:
+    type: array
+    items:
+      $ref: "#/MessageChannel"
+  description: |-
+    All the notification channels blocked by the user.
+    Each channel is related to a specific service (sender).
 LimitedProfile:
   description: |-
     Describes the citizen's profile, mostly interesting for preferences
@@ -242,6 +271,8 @@ ExtendedProfile:
   properties:
     email:
       $ref: "#/EmailAddress"
+    blocked_channels:
+      $ref: "#/BlockedChannels"
     preferred_languages:
       $ref: "#/PreferredLanguages"
     is_inbox_enabled:

--- a/api/definitions.yaml
+++ b/api/definitions.yaml
@@ -38,7 +38,7 @@ NotificationChannel:
     - EMAIL
     - WEBHOOK
   example: EMAIL
-MessageChannel:
+BlockedChannel:
   type: string
   description: |-
     All notification channels plus the message inbox.
@@ -238,20 +238,12 @@ PaginationResponse:
         retrieved collection of items.
       format: uri
       example: https://example.com/?p=0XXX2
-BlockedChannel:
-  description: |-
-    A notification channel (ie. email) blocked by the user.
-    The channel is related to a specific service (sender).
-  type: object
-  properties:
-    service_id:
-      $ref: "#/ServiceId"
 BlockedChannels:
   type: object
   additionalProperties:
     type: array
     items:
-      $ref: "#/MessageChannel"
+      $ref: "#/BlockedChannel"
   description: |-
     All the notification channels blocked by the user.
     Each channel is related to a specific service (sender).

--- a/api/definitions.yaml
+++ b/api/definitions.yaml
@@ -38,7 +38,7 @@ NotificationChannel:
     - EMAIL
     - WEBHOOK
   example: EMAIL
-BlockedChannel:
+BlockedInboxOrChannel:
   type: string
   description: |-
     All notification channels plus the message inbox.
@@ -238,12 +238,12 @@ PaginationResponse:
         retrieved collection of items.
       format: uri
       example: https://example.com/?p=0XXX2
-BlockedChannels:
+BlockedInboxOrChannels:
   type: object
   additionalProperties:
     type: array
     items:
-      $ref: "#/BlockedChannel"
+      $ref: "#/BlockedInboxOrChannel"
   description: |-
     All the notification channels blocked by the user.
     Each channel is related to a specific service (sender).
@@ -263,8 +263,8 @@ ExtendedProfile:
   properties:
     email:
       $ref: "#/EmailAddress"
-    blocked_channels:
-      $ref: "#/BlockedChannels"
+    blocked_inbox_or_channels:
+      $ref: "#/BlockedInboxOrChannels"
     preferred_languages:
       $ref: "#/PreferredLanguages"
     is_inbox_enabled:

--- a/lib/controllers/__tests__/messages.test.ts
+++ b/lib/controllers/__tests__/messages.test.ts
@@ -59,14 +59,8 @@ import {
 import * as lolex from "lolex";
 
 // mock time (ie. created_at)
-// tslint:disable-next-line:no-let
-let clock: any;
-beforeEach(() => {
-  clock = lolex.install();
-});
-afterEach(() => {
-  clock.uninstall();
-});
+const clock = lolex.install();
+afterAll(() => clock.uninstall());
 
 afterEach(() => {
   jest.resetAllMocks();

--- a/lib/controllers/profiles.ts
+++ b/lib/controllers/profiles.ts
@@ -57,7 +57,7 @@ import { ServiceModel } from "../models/service";
 
 function toExtendedProfile(profile: RetrievedProfile): ExtendedProfile {
   return {
-    blocked_channels: profile.blockedChannels,
+    blocked_inbox_or_channels: profile.blockedInboxOrChannels,
     email: profile.email,
     is_inbox_enabled: profile.isInboxEnabled,
     is_webhook_enabled: profile.isWebhookEnabled,
@@ -193,7 +193,7 @@ async function createNewProfileFromPayload(
 ): Promise<IResponseSuccessJson<ExtendedProfile> | IResponseErrorQuery> {
   // create a new profile
   const profile: Profile = {
-    blockedChannels: profileModelPayload.blocked_channels,
+    blockedInboxOrChannels: profileModelPayload.blocked_inbox_or_channels,
     email: profileModelPayload.email,
     fiscalCode,
     isInboxEnabled: profileModelPayload.is_inbox_enabled,
@@ -229,7 +229,7 @@ async function updateExistingProfileFromPayload(
     p => {
       return {
         ...p,
-        blockedChannels: profileModelPayload.blocked_channels,
+        blockedInboxOrChannels: profileModelPayload.blocked_inbox_or_channels,
         email: profileModelPayload.email,
         isInboxEnabled: profileModelPayload.is_inbox_enabled,
         isWebhookEnabled: profileModelPayload.is_webhook_enabled,

--- a/lib/controllers/profiles.ts
+++ b/lib/controllers/profiles.ts
@@ -57,6 +57,7 @@ import { ServiceModel } from "../models/service";
 
 function toExtendedProfile(profile: RetrievedProfile): ExtendedProfile {
   return {
+    blocked_channels: profile.blockedChannels,
     email: profile.email,
     is_inbox_enabled: profile.isInboxEnabled,
     is_webhook_enabled: profile.isWebhookEnabled,
@@ -192,6 +193,7 @@ async function createNewProfileFromPayload(
 ): Promise<IResponseSuccessJson<ExtendedProfile> | IResponseErrorQuery> {
   // create a new profile
   const profile: Profile = {
+    blockedChannels: profileModelPayload.blocked_channels,
     email: profileModelPayload.email,
     fiscalCode,
     isInboxEnabled: profileModelPayload.is_inbox_enabled,
@@ -227,6 +229,7 @@ async function updateExistingProfileFromPayload(
     p => {
       return {
         ...p,
+        blockedChannels: profileModelPayload.blocked_channels,
         email: profileModelPayload.email,
         isInboxEnabled: profileModelPayload.is_inbox_enabled,
         isWebhookEnabled: profileModelPayload.is_webhook_enabled,

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -226,6 +226,7 @@ async function createNotification(
  *          a TransientError in case of recoverable errors
  *          a PermanentError in case of unrecoverable error
  */
+// tslint:disable-next-line:cognitive-complexity
 export async function handleMessage(
   lProfileModel: ProfileModel,
   lMessageModel: MessageModel,
@@ -313,7 +314,7 @@ export async function handleMessage(
 
   if (isEmailBlockedForService) {
     winston.debug(
-      `User has blocked email notifications for this serviceId|${
+      `handleMessage|User has blocked email notifications for this serviceId|${
         newMessageWithContent.fiscalCode
       }:${newMessageWithContent.senderServiceId}`
     );
@@ -333,7 +334,7 @@ export async function handleMessage(
 
   if (noEmailAddressFound) {
     winston.debug(
-      `Fiscal code has no associated email address and no default email address was provided|${
+      `handleMessage|User profile has no email address set and no default address was provided|${
         newMessageWithContent.fiscalCode
       }`
     );
@@ -350,7 +351,7 @@ export async function handleMessage(
 
   if (isWebhookBlockedForService) {
     winston.debug(
-      `User has blocked webhook notifications for this serviceId|${
+      `handleMessage|User has blocked webhook notifications for this serviceId|${
         newMessageWithContent.fiscalCode
       }:${newMessageWithContent.senderServiceId}`
     );
@@ -377,7 +378,7 @@ export async function handleMessage(
       PermanentError(
         `No channels configured for the user ${
           newMessageWithContent.fiscalCode
-        }`
+        } and no default address provided`
       )
     );
   }

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -278,7 +278,7 @@ export async function handleMessage(
   //  Inbox storage
   //
 
-  // check if the user has blocked webhook notifications sent from this service
+  // check if the user has blocked inbox message storage from this service
   const userHasBlockedMessageStorage = blockedChannels.has(
     BlockedChannelEnum.INBOX
   );

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -226,7 +226,6 @@ async function createNotification(
  *          a TransientError in case of recoverable errors
  *          a PermanentError in case of unrecoverable error
  */
-// tslint:disable-next-line:cognitive-complexity
 export async function handleMessage(
   lProfileModel: ProfileModel,
   lMessageModel: MessageModel,
@@ -327,18 +326,17 @@ export async function handleMessage(
         .chain(getEmailAddressFromProfile)
         // if it's not set, or we don't have a profile for this fiscal code,
         // try to get the default email address from the request payload
-        .alt(defaultAddresses.chain(getEmailAddressFromDefaultAddresses));
-
-  const noEmailAddressFound =
-    maybeAllowedEmailNotification.isNone() && !isEmailBlockedForService;
-
-  if (noEmailAddressFound) {
-    winston.debug(
-      `handleMessage|User profile has no email address set and no default address was provided|${
-        newMessageWithContent.fiscalCode
-      }`
-    );
-  }
+        .alt(defaultAddresses.chain(getEmailAddressFromDefaultAddresses))
+        .alt(
+          (() => {
+            winston.debug(
+              `handleMessage|User profile has no email address set and no default address was provided|${
+                newMessageWithContent.fiscalCode
+              }`
+            );
+            return none;
+          })()
+        );
 
   //
   //  Webhook notification

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -356,9 +356,12 @@ export async function handleMessage(
   }
 
   // whether the recipient wants us to send notifications to the app backend
+  const isWebhookBlockedInProfile = maybeProfile.exists(
+    profile => profile.isWebhookEnabled === true
+  );
+
   const isWebhookEnabled =
-    !isWebhookBlockedForService &&
-    maybeProfile.exists(profile => profile.isWebhookEnabled === true);
+    !isWebhookBlockedForService && isWebhookBlockedInProfile;
 
   const maybeAllowedWebhookNotification = isWebhookEnabled
     ? some({

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -48,7 +48,11 @@ import {
   NotificationModel
 } from "./models/notification";
 import { NotificationEvent } from "./models/notification_event";
-import { ProfileModel, RetrievedProfile } from "./models/profile";
+import {
+  IProfileBlockedChannels,
+  ProfileModel,
+  RetrievedProfile
+} from "./models/profile";
 
 import { Either, isLeft, left, right } from "fp-ts/lib/Either";
 import { readableReport } from "italia-ts-commons/lib/reporters";
@@ -258,15 +262,14 @@ export async function handleMessage(
   const maybeProfile = errorOrMaybeProfile.value;
 
   // channels ther user has blocked for this sender service
-  const blockedChannels = new Set(
-    maybeProfile
-      .chain(profile =>
-        fromNullable(profile.blockedChannels).map(
-          bc => bc[newMessageWithContent.senderServiceId]
-        )
+  const blockedChannels = maybeProfile
+    .chain(profile =>
+      fromNullable(profile.blockedChannels).map(
+        (bc: IProfileBlockedChannels) =>
+          bc[newMessageWithContent.senderServiceId]
       )
-      .getOrElse([])
-  );
+    )
+    .getOrElse(new Set());
 
   winston.debug(
     "handleMessage|Blocked Channels(%s): %s",

--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -307,9 +307,9 @@ export async function handleMessage(
   // check if the user has blocked emails sent from this service
   // 'some(true)' in case we must send the notification by email
   // 'none' in case the user has blocked the email channel
-  const isEmailBlockedForService = blockedInboxOrChannels.has(
-    BlockedInboxOrChannelEnum.EMAIL
-  );
+  const isEmailBlockedForService =
+    isMessageStorageBlockedForService ||
+    blockedInboxOrChannels.has(BlockedInboxOrChannelEnum.EMAIL);
 
   if (isEmailBlockedForService) {
     winston.debug(
@@ -341,9 +341,9 @@ export async function handleMessage(
   //
 
   // check if the user has blocked webhook notifications sent from this service
-  const isWebhookBlockedForService = blockedInboxOrChannels.has(
-    BlockedInboxOrChannelEnum.WEBHOOK
-  );
+  const isWebhookBlockedForService =
+    isMessageStorageBlockedForService ||
+    blockedInboxOrChannels.has(BlockedInboxOrChannelEnum.WEBHOOK);
 
   if (isWebhookBlockedForService) {
     winston.debug(

--- a/lib/models/profile.ts
+++ b/lib/models/profile.ts
@@ -15,7 +15,7 @@ import { Option } from "fp-ts/lib/Option";
 
 import { NonNegativeNumber } from "italia-ts-commons/lib/numbers";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
-import { BlockedChannel } from "../api/definitions/BlockedChannel";
+import { BlockedInboxOrChannel } from "../api/definitions/BlockedInboxOrChannel";
 import { EmailAddress } from "../api/definitions/EmailAddress";
 import { FiscalCode } from "../api/definitions/FiscalCode";
 import { IsInboxEnabled } from "../api/definitions/IsInboxEnabled";
@@ -24,15 +24,15 @@ import { PreferredLanguages } from "../api/definitions/PreferredLanguages";
 import { ServiceId } from "../api/definitions/ServiceId";
 import { fiscalCodeToModelId } from "../utils/conversions";
 
-const ProfileBlockedChannels = t.dictionary(
+const ProfileBlockedInboxOrChannels = t.dictionary(
   ServiceId,
-  readonlySetType(BlockedChannel, "ProfileBlockedChannel"),
-  "ProfileBlockedChannels"
+  readonlySetType(BlockedInboxOrChannel, "ProfileBlockedInboxOrChannel"),
+  "ProfileBlockedInboxOrChannels"
 );
 
 // typescript does not allow to have ServiceId as key type here
-export interface IProfileBlockedChannels {
-  readonly [serviceId: string]: ReadonlySet<BlockedChannel>;
+export interface IProfileBlockedInboxOrChannels {
+  readonly [serviceId: string]: ReadonlySet<BlockedInboxOrChannel>;
 }
 
 /**
@@ -46,7 +46,7 @@ export const Profile = t.intersection([
   t.partial({
     // Notification channels blocked by the user;
     // each channel is related to a specific Service (sender)
-    blockedChannels: ProfileBlockedChannels,
+    blockedInboxOrChannels: ProfileBlockedInboxOrChannels,
 
     // the preferred email for receiving email notifications
     // if defined, will override the default email provided by the API client

--- a/lib/models/profile.ts
+++ b/lib/models/profile.ts
@@ -1,6 +1,6 @@
 import * as t from "io-ts";
 
-import { tag } from "italia-ts-commons/lib/types";
+import { readonlySetType, tag } from "italia-ts-commons/lib/types";
 
 import * as DocumentDb from "documentdb";
 import * as DocumentDbUtils from "../utils/documentdb";
@@ -15,13 +15,25 @@ import { Option } from "fp-ts/lib/Option";
 
 import { NonNegativeNumber } from "italia-ts-commons/lib/numbers";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
-import { BlockedChannels } from "../api/definitions/BlockedChannels";
+import { BlockedChannel } from "../api/definitions/BlockedChannel";
 import { EmailAddress } from "../api/definitions/EmailAddress";
 import { FiscalCode } from "../api/definitions/FiscalCode";
 import { IsInboxEnabled } from "../api/definitions/IsInboxEnabled";
 import { IsWebhookEnabled } from "../api/definitions/IsWebhookEnabled";
 import { PreferredLanguages } from "../api/definitions/PreferredLanguages";
+import { ServiceId } from "../api/definitions/ServiceId";
 import { fiscalCodeToModelId } from "../utils/conversions";
+
+const ProfileBlockedChannels = t.dictionary(
+  ServiceId,
+  readonlySetType(BlockedChannel, "ProfileBlockedChannel"),
+  "ProfileBlockedChannels"
+);
+
+// typescript does not allow to have ServiceId as key type here
+export interface IProfileBlockedChannels {
+  readonly [serviceId: string]: ReadonlySet<BlockedChannel>;
+}
 
 /**
  * Base interface for Profile objects
@@ -34,7 +46,7 @@ export const Profile = t.intersection([
   t.partial({
     // Notification channels blocked by the user;
     // each channel is related to a specific Service (sender)
-    blockedChannels: BlockedChannels,
+    blockedChannels: ProfileBlockedChannels,
 
     // the preferred email for receiving email notifications
     // if defined, will override the default email provided by the API client

--- a/lib/models/profile.ts
+++ b/lib/models/profile.ts
@@ -15,6 +15,7 @@ import { Option } from "fp-ts/lib/Option";
 
 import { NonNegativeNumber } from "italia-ts-commons/lib/numbers";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { BlockedChannels } from "../api/definitions/BlockedChannels";
 import { EmailAddress } from "../api/definitions/EmailAddress";
 import { FiscalCode } from "../api/definitions/FiscalCode";
 import { IsInboxEnabled } from "../api/definitions/IsInboxEnabled";
@@ -31,6 +32,10 @@ export const Profile = t.intersection([
     fiscalCode: FiscalCode
   }),
   t.partial({
+    // Notification channels blocked by the user;
+    // each channel is related to a specific Service (sender)
+    blockedChannels: BlockedChannels,
+
     // the preferred email for receiving email notifications
     // if defined, will override the default email provided by the API client
     // if defined, will enable email notifications for the citizen

--- a/lib/types/url.d.ts
+++ b/lib/types/url.d.ts
@@ -1,3 +1,0 @@
-declare module "url" {
-  type URL = string;
-}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint -p . -c tslint.json -t verbose",
     "prettify": "prettier --write './**/*.ts'",
     "test": "gulp test",
-    "generate:models:clean": "rimraf lib/api/definitions/* && ls lib/api",
+    "generate:models:clean": "rimraf lib/api/definitions/*",
     "generate:models:public_api_v1": "gen-api-models --api-spec ./api/public_api_v1.yaml --out-dir ./lib/api/definitions --ts-spec-file ./lib/api/public_api_v1.ts",
     "generate:models:admin_api": "gen-api-models --api-spec ./api/admin_api.yaml --out-dir ./lib/api/definitions --ts-spec-file ./lib/api/admin_api.ts",
     "generate:models": "npm-run-all -s generate:models:*",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-run": "^1.7.1",
     "gulp-text-simple": "^0.4.1",
-    "italia-utils": "^3.7.0",
+    "italia-utils": "^3.7.1",
     "jest": "^22.0.0",
     "jest-mock-express": "^0.1.1",
     "lolex": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint -p . -c tslint.json -t verbose",
     "prettify": "prettier --write './**/*.ts'",
     "test": "gulp test",
-    "generate:models:clean": "rimraf lib/api/definitions/*",
+    "generate:models:clean": "rimraf lib/api/definitions/* && ls lib/api",
     "generate:models:public_api_v1": "gen-api-models --api-spec ./api/public_api_v1.yaml --out-dir ./lib/api/definitions --ts-spec-file ./lib/api/public_api_v1.ts",
     "generate:models:admin_api": "gen-api-models --api-spec ./api/admin_api.yaml --out-dir ./lib/api/definitions --ts-spec-file ./lib/api/admin_api.ts",
     "generate:models": "npm-run-all -s generate:models:*",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build:tsc": "tsc",
     "build:tsc-noemit": "tsc --noEmit",
-    "build": "npm-run-all generate:models generate:templates build:tsc",
+    "build": "npm-run-all -s generate:models generate:templates build:tsc",
     "lint": "tslint -p . -c tslint.json -t verbose",
     "prettify": "prettier --write './**/*.ts'",
     "test": "gulp test",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-run": "^1.7.1",
     "gulp-text-simple": "^0.4.1",
-    "italia-utils": "^2.1.0",
+    "italia-utils": "^3.7.0",
     "jest": "^22.0.0",
     "jest-mock-express": "^0.1.1",
     "lolex": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,9 +2580,9 @@ fs-extra@6.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+fs-extra@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -3700,11 +3700,11 @@ italia-ts-commons@^1.0.0:
     json-set-map "^1.0.2"
     validator "^9.4.1"
 
-italia-utils@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/italia-utils/-/italia-utils-2.1.0.tgz#90536c3c29ad63d47ecceb81fdbc89eb7051800a"
+italia-utils@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/italia-utils/-/italia-utils-3.7.0.tgz#5f6bd5d9442840b1bcdea155afb8c398e16ed6c8"
   dependencies:
-    fs-extra "^5.0.0"
+    fs-extra "^6.0.0"
     nunjucks "^3.1.2"
     prettier "^1.12.1"
     swagger-parser "^4.1.0"
@@ -4866,8 +4866,8 @@ lodash@~1.0.1:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
 
 lolex@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.4.1.tgz#960884895837916e8963a54e58edf97c95d3060c"
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.4.2.tgz#d1d8df28fac51920b969aea10f90366b4c0d5e93"
 
 longest@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3700,9 +3700,9 @@ italia-ts-commons@^1.0.0:
     json-set-map "^1.0.2"
     validator "^9.4.1"
 
-italia-utils@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/italia-utils/-/italia-utils-3.7.0.tgz#5f6bd5d9442840b1bcdea155afb8c398e16ed6c8"
+italia-utils@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/italia-utils/-/italia-utils-3.7.1.tgz#7e6f550744edf2552644945d927d85b798ddaa72"
   dependencies:
     fs-extra "^6.0.0"
     nunjucks "^3.1.2"


### PR DESCRIPTION
## Abstract

- adds a new property "blocked_channels" to the profile model 
`{ serviceId: [ array of blocked channels ]}`

- adds logic to skip blocked channel into created_message_queue_handler

profile model: 

```
{
    "blocked_channels": {
        "5a25abf4fcc89605c082f042c49a": [
            "EMAIL",
            "WEBHOOK"
        ]
    },
    "email": "xxxxxxxxx@xxxxxxx.com",
    "is_inbox_enabled": true,
    "is_webhook_enabled": true,
    "preferred_languages": [
        "it_IT"
    ],
    "version": 46
}

```

There at least are a couple of possible implementation. The one in "Scenario 1" is implemented in the current PR.

### Scenario 1

We block notifications in the `created_message_queue_handler`, before dispatching the messages to the channel queue handlers.

**Pros**: efficient as it avoids to send notifications to the channels queue handlers
**Cons**: there are some chances that the "blocked" messages are dispatched to the user in case the act of block a channel occurs *after* the message is already dispatched to the specific channel queue handler: these handlers will send the messages without any further check.

### Scenario 2

We dispatch the notifications to the specific channel queue handlers (anyway), only then we check if the user has blocked the specific channel.

**Pros**: no chance the user wil receive any notification after blocking any channel
**Cons**: require an extra call to retrieve the user's profile in the specific channel queue handler, pollute channel queues with notifications that won't be sent

## Decisions to take

What to return in the notification-status for blocked messages ? (actually we do not save any status, which is the same behavior we get when a notification is not sent for any other reason).

## TODO

- add tests
