### PR TITLE
[#151202533] add telemetry and insights

### DIFF
--- a/lib/__tests__/created_message_queue_handler.test.ts
+++ b/lib/__tests__/created_message_queue_handler.test.ts
@@ -43,6 +43,7 @@ import { TimeToLiveSeconds } from "../api/definitions/TimeToLiveSeconds";
 import { NotificationEvent } from "../models/notification_event";
 
 jest.mock("azure-storage");
+jest.mock("applicationinsights");
 jest.mock("../utils/azure_queues");
 import { handleQueueProcessingFailure } from "../utils/azure_queues";
 

--- a/lib/controllers/__tests__/messages.test.ts
+++ b/lib/controllers/__tests__/messages.test.ts
@@ -57,6 +57,8 @@ import {
 import * as lolex from "lolex";
 import { ServiceId } from "../../api/definitions/ServiceId";
 
+jest.mock("applicationinsights");
+
 // mock time (ie. created_at)
 const clock = lolex.install();
 afterAll(() => clock.uninstall());
@@ -64,6 +66,12 @@ afterAll(() => clock.uninstall());
 afterEach(() => {
   jest.resetAllMocks();
   jest.restoreAllMocks();
+});
+
+const trackEventMock = jest.fn();
+
+const getCustomTelemetryClient = () => ({
+  trackEvent: trackEventMock
 });
 
 interface IHeaders {
@@ -205,6 +213,7 @@ describe("CreateMessageHandler", () => {
     };
 
     const createMessageHandler = CreateMessageHandler(
+      getCustomTelemetryClient as any,
       mockMessageModel as any,
       {} as any
     );
@@ -233,15 +242,12 @@ describe("CreateMessageHandler", () => {
   });
 
   it("should create a new message", async () => {
-    const mockAppInsights = {
-      trackEvent: jest.fn()
-    };
-
     const mockMessageModel = {
       create: jest.fn(() => right(aRetrievedMessageWithoutContent))
     };
 
     const createMessageHandler = CreateMessageHandler(
+      getCustomTelemetryClient as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -289,17 +295,19 @@ describe("CreateMessageHandler", () => {
       }
     });
 
-    expect(mockAppInsights.trackEvent).toHaveBeenCalledTimes(1);
-    expect(mockAppInsights.trackEvent).toHaveBeenCalledWith({
-      name: "api.messages.create",
-      properties: {
-        hasCustomSubject: "false",
-        hasDefaultEmail: "false",
-        senderServiceId: "test",
-        senderUserId: "u123",
-        success: "true"
-      }
-    });
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
+    expect(trackEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "api.messages.create",
+        properties: {
+          hasCustomSubject: "false",
+          hasDefaultEmail: "false",
+          senderServiceId: "test",
+          senderUserId: "u123",
+          success: "true"
+        }
+      })
+    );
 
     expect(result.kind).toBe("IResponseSuccessRedirectToResource");
     if (result.kind === "IResponseSuccessRedirectToResource") {
@@ -313,15 +321,12 @@ describe("CreateMessageHandler", () => {
   });
 
   it("should create a new message for a limited auhorization recipient", async () => {
-    const mockAppInsights = {
-      trackEvent: jest.fn()
-    };
-
     const mockMessageModel = {
       create: jest.fn(() => right(aRetrievedMessageWithoutContent))
     };
 
     const createMessageHandler = CreateMessageHandler(
+      getCustomTelemetryClient as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -379,17 +384,19 @@ describe("CreateMessageHandler", () => {
       }
     });
 
-    expect(mockAppInsights.trackEvent).toHaveBeenCalledTimes(1);
-    expect(mockAppInsights.trackEvent).toHaveBeenCalledWith({
-      name: "api.messages.create",
-      properties: {
-        hasCustomSubject: "false",
-        hasDefaultEmail: "false",
-        senderServiceId: "test",
-        senderUserId: "u123",
-        success: "true"
-      }
-    });
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
+    expect(trackEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "api.messages.create",
+        properties: {
+          hasCustomSubject: "false",
+          hasDefaultEmail: "false",
+          senderServiceId: "test",
+          senderUserId: "u123",
+          success: "true"
+        }
+      })
+    );
 
     expect(result.kind).toBe("IResponseSuccessRedirectToResource");
     if (result.kind === "IResponseSuccessRedirectToResource") {
@@ -403,15 +410,12 @@ describe("CreateMessageHandler", () => {
   });
 
   it("should handle custom subject", async () => {
-    const mockAppInsights = {
-      trackEvent: jest.fn()
-    };
-
     const mockMessageModel = {
       create: jest.fn(() => right(aRetrievedMessageWithoutContent))
     };
 
     const createMessageHandler = CreateMessageHandler(
+      getCustomTelemetryClient as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -466,17 +470,19 @@ describe("CreateMessageHandler", () => {
       }
     });
 
-    expect(mockAppInsights.trackEvent).toHaveBeenCalledTimes(1);
-    expect(mockAppInsights.trackEvent).toHaveBeenCalledWith({
-      name: "api.messages.create",
-      properties: {
-        hasCustomSubject: "true",
-        hasDefaultEmail: "false",
-        senderServiceId: "test",
-        senderUserId: "u123",
-        success: "true"
-      }
-    });
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
+    expect(trackEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "api.messages.create",
+        properties: {
+          hasCustomSubject: "true",
+          hasDefaultEmail: "false",
+          senderServiceId: "test",
+          senderUserId: "u123",
+          success: "true"
+        }
+      })
+    );
 
     expect(result.kind).toBe("IResponseSuccessRedirectToResource");
     if (result.kind === "IResponseSuccessRedirectToResource") {
@@ -490,10 +496,6 @@ describe("CreateMessageHandler", () => {
   });
 
   it("should handle default addresses when creating a new message", async () => {
-    const mockAppInsights = {
-      trackEvent: jest.fn()
-    };
-
     const mockMessageModel = {
       create: jest.fn(() =>
         Promise.resolve(right(aRetrievedMessageWithoutContent))
@@ -501,6 +503,7 @@ describe("CreateMessageHandler", () => {
     };
 
     const createMessageHandler = CreateMessageHandler(
+      getCustomTelemetryClient as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -562,17 +565,19 @@ describe("CreateMessageHandler", () => {
       }
     });
 
-    expect(mockAppInsights.trackEvent).toHaveBeenCalledTimes(1);
-    expect(mockAppInsights.trackEvent).toHaveBeenCalledWith({
-      name: "api.messages.create",
-      properties: {
-        hasCustomSubject: "false",
-        hasDefaultEmail: "true",
-        senderServiceId: "test",
-        senderUserId: "u123",
-        success: "true"
-      }
-    });
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
+    expect(trackEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "api.messages.create",
+        properties: {
+          hasCustomSubject: "false",
+          hasDefaultEmail: "true",
+          senderServiceId: "test",
+          senderUserId: "u123",
+          success: "true"
+        }
+      })
+    );
 
     expect(result.kind).toBe("IResponseSuccessRedirectToResource");
     if (result.kind === "IResponseSuccessRedirectToResource") {
@@ -586,15 +591,12 @@ describe("CreateMessageHandler", () => {
   });
 
   it("should require the user to be enabled for providing default addresses when creating a new message", async () => {
-    const mockAppInsights = {
-      trackEvent: jest.fn()
-    };
-
     const mockMessageModel = {
       create: jest.fn(() => right(aRetrievedMessageWithoutContent))
     };
 
     const createMessageHandler = CreateMessageHandler(
+      getCustomTelemetryClient as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -626,7 +628,7 @@ describe("CreateMessageHandler", () => {
       createdMessage: undefined
     });
 
-    expect(mockAppInsights.trackEvent).not.toHaveBeenCalled();
+    expect(trackEventMock).not.toHaveBeenCalled();
 
     expect(result.kind).toBe(
       "IResponseErrorForbiddenNotAuthorizedForDefaultAddresses"
@@ -639,6 +641,7 @@ describe("CreateMessageHandler", () => {
     };
 
     const createMessageHandler = CreateMessageHandler(
+      getCustomTelemetryClient as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -668,15 +671,12 @@ describe("CreateMessageHandler", () => {
   });
 
   it("should return failure if creation fails", async () => {
-    const mockAppInsights = {
-      trackEvent: jest.fn()
-    };
-
     const mockMessageModel = {
       create: jest.fn(() => left("error"))
     };
 
     const createMessageHandler = CreateMessageHandler(
+      getCustomTelemetryClient as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -699,18 +699,20 @@ describe("CreateMessageHandler", () => {
     );
 
     expect(mockMessageModel.create).toHaveBeenCalledTimes(1);
-    expect(mockAppInsights.trackEvent).toHaveBeenCalledTimes(1);
-    expect(mockAppInsights.trackEvent).toHaveBeenCalledWith({
-      name: "api.messages.create",
-      properties: {
-        error: "IResponseErrorQuery",
-        hasCustomSubject: "false",
-        hasDefaultEmail: "false",
-        senderServiceId: "test",
-        senderUserId: "u123",
-        success: "false"
-      }
-    });
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
+    expect(trackEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "api.messages.create",
+        properties: {
+          error: "IResponseErrorQuery",
+          hasCustomSubject: "false",
+          hasDefaultEmail: "false",
+          senderServiceId: "test",
+          senderUserId: "u123",
+          success: "false"
+        }
+      })
+    );
 
     expect(mockContext.bindings).toEqual({});
     expect(result.kind).toBe("IResponseErrorQuery");
@@ -1153,7 +1155,7 @@ describe("CreateMessage", () => {
       "x-subscription-id": "someId",
       "x-user-groups": "ApiMessageWrite"
     };
-    const createMessage = CreateMessage({} as any, {} as any);
+    const createMessage = CreateMessage({} as any, {} as any, {} as any);
     const mockResponse = MockResponse();
     const request = {
       app: {
@@ -1176,7 +1178,7 @@ describe("CreateMessage", () => {
     const headers: IHeaders = {
       "x-user-groups": ""
     };
-    const createMessage = CreateMessage({} as any, {} as any);
+    const createMessage = CreateMessage({} as any, {} as any, {} as any);
     const mockResponse = MockResponse();
     const request = {
       app: {
@@ -1201,7 +1203,7 @@ describe("CreateMessage", () => {
       "x-subscription-id": "someId",
       "x-user-groups": "ApiMessageWrite"
     };
-    const createMessage = CreateMessage({} as any, {} as any);
+    const createMessage = CreateMessage({} as any, {} as any, {} as any);
     const mockResponse = MockResponse();
     const request = {
       app: {

--- a/lib/controllers/__tests__/messages.test.ts
+++ b/lib/controllers/__tests__/messages.test.ts
@@ -205,7 +205,6 @@ describe("CreateMessageHandler", () => {
     };
 
     const createMessageHandler = CreateMessageHandler(
-      {} as any,
       mockMessageModel as any,
       {} as any
     );
@@ -243,7 +242,6 @@ describe("CreateMessageHandler", () => {
     };
 
     const createMessageHandler = CreateMessageHandler(
-      mockAppInsights as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -324,7 +322,6 @@ describe("CreateMessageHandler", () => {
     };
 
     const createMessageHandler = CreateMessageHandler(
-      mockAppInsights as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -415,7 +412,6 @@ describe("CreateMessageHandler", () => {
     };
 
     const createMessageHandler = CreateMessageHandler(
-      mockAppInsights as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -505,7 +501,6 @@ describe("CreateMessageHandler", () => {
     };
 
     const createMessageHandler = CreateMessageHandler(
-      mockAppInsights as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -600,7 +595,6 @@ describe("CreateMessageHandler", () => {
     };
 
     const createMessageHandler = CreateMessageHandler(
-      mockAppInsights as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -640,16 +634,11 @@ describe("CreateMessageHandler", () => {
   });
 
   it("should require the user to be enable for production to create a new message", async () => {
-    const mockAppInsights = {
-      trackEvent: jest.fn()
-    };
-
     const mockMessageModel = {
       create: jest.fn(() => right(aRetrievedMessageWithoutContent))
     };
 
     const createMessageHandler = CreateMessageHandler(
-      mockAppInsights as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -688,7 +677,6 @@ describe("CreateMessageHandler", () => {
     };
 
     const createMessageHandler = CreateMessageHandler(
-      mockAppInsights as any,
       mockMessageModel as any,
       () => aMessageId
     );
@@ -1165,7 +1153,7 @@ describe("CreateMessage", () => {
       "x-subscription-id": "someId",
       "x-user-groups": "ApiMessageWrite"
     };
-    const createMessage = CreateMessage({} as any, {} as any, {} as any);
+    const createMessage = CreateMessage({} as any, {} as any);
     const mockResponse = MockResponse();
     const request = {
       app: {
@@ -1188,7 +1176,7 @@ describe("CreateMessage", () => {
     const headers: IHeaders = {
       "x-user-groups": ""
     };
-    const createMessage = CreateMessage({} as any, {} as any, {} as any);
+    const createMessage = CreateMessage({} as any, {} as any);
     const mockResponse = MockResponse();
     const request = {
       app: {
@@ -1213,7 +1201,7 @@ describe("CreateMessage", () => {
       "x-subscription-id": "someId",
       "x-user-groups": "ApiMessageWrite"
     };
-    const createMessage = CreateMessage({} as any, {} as any, {} as any);
+    const createMessage = CreateMessage({} as any, {} as any);
     const mockResponse = MockResponse();
     const request = {
       app: {

--- a/lib/controllers/messages.ts
+++ b/lib/controllers/messages.ts
@@ -108,7 +108,7 @@ import { TimeToLiveSeconds } from "../api/definitions/TimeToLiveSeconds";
 import { MessageStatusModel } from "../models/message_status";
 import { NotificationStatusModel } from "../models/notification_status";
 import {
-  CustomTelemetryClient,
+  CustomTelemetryClientFactory,
   diffInMilliseconds
 } from "../utils/application_insights";
 
@@ -324,7 +324,7 @@ async function getMessageNotificationStatuses(
  * Returns a type safe CreateMessage handler.
  */
 export function CreateMessageHandler(
-  getCustomTelemetryClient: CustomTelemetryClient,
+  getCustomTelemetryClient: CustomTelemetryClientFactory,
   messageModel: MessageModel,
   generateObjectId: ObjectIdGenerator
 ): ICreateMessageHandler {
@@ -510,7 +510,7 @@ export function CreateMessageHandler(
  * Wraps a CreateMessage handler inside an Express request handler.
  */
 export function CreateMessage(
-  getCustomTelemetryClient: CustomTelemetryClient,
+  getCustomTelemetryClient: CustomTelemetryClientFactory,
   serviceModel: ServiceModel,
   messageModel: MessageModel
 ): express.RequestHandler {

--- a/lib/controllers/messages.ts
+++ b/lib/controllers/messages.ts
@@ -99,7 +99,6 @@ import {
   some
 } from "fp-ts/lib/Option";
 
-import { TelemetryClient } from "applicationinsights";
 import { CreatedMessageWithContent } from "../api/definitions/CreatedMessageWithContent";
 import { MessageResponseWithoutContent } from "../api/definitions/MessageResponseWithoutContent";
 import { MessageStatusValueEnum } from "../api/definitions/MessageStatusValue";

--- a/lib/controllers/messages.ts
+++ b/lib/controllers/messages.ts
@@ -109,16 +109,9 @@ import { TimeToLiveSeconds } from "../api/definitions/TimeToLiveSeconds";
 import { MessageStatusModel } from "../models/message_status";
 import { NotificationStatusModel } from "../models/notification_status";
 import {
-  diffInMilliseconds,
-  wrapCustomTelemetryClient
+  CustomTelemetryClient,
+  diffInMilliseconds
 } from "../utils/application_insights";
-
-const isProduction = process.env.NODE_ENV === "production";
-
-const getCustomTelemetryClient = wrapCustomTelemetryClient(
-  isProduction,
-  new TelemetryClient()
-);
 
 /**
  * Input and output bindings for this function
@@ -332,6 +325,7 @@ async function getMessageNotificationStatuses(
  * Returns a type safe CreateMessage handler.
  */
 export function CreateMessageHandler(
+  getCustomTelemetryClient: CustomTelemetryClient,
   messageModel: MessageModel,
   generateObjectId: ObjectIdGenerator
 ): ICreateMessageHandler {
@@ -517,10 +511,15 @@ export function CreateMessageHandler(
  * Wraps a CreateMessage handler inside an Express request handler.
  */
 export function CreateMessage(
+  getCustomTelemetryClient: CustomTelemetryClient,
   serviceModel: ServiceModel,
   messageModel: MessageModel
 ): express.RequestHandler {
-  const handler = CreateMessageHandler(messageModel, ulidGenerator);
+  const handler = CreateMessageHandler(
+    getCustomTelemetryClient,
+    messageModel,
+    ulidGenerator
+  );
   const middlewaresWrap = withRequestMiddlewares(
     // extract Azure Functions bindings
     ContextMiddleware<IBindings>(),

--- a/lib/public_api_v1.ts
+++ b/lib/public_api_v1.ts
@@ -49,8 +49,16 @@ import {
   SenderServiceModel
 } from "./models/sender_service";
 
+import { TelemetryClient } from "applicationinsights";
+import { wrapCustomTelemetryClient } from "./utils/application_insights";
+
 // Whether we're in a production environment
 const isProduction = process.env.NODE_ENV === "production";
+
+const getCustomTelemetryClient = wrapCustomTelemetryClient(
+  isProduction,
+  new TelemetryClient()
+);
 
 // Setup Express
 const app = express();
@@ -167,7 +175,7 @@ app.get(
 );
 app.post(
   "/api/v1/messages/:fiscalcode",
-  CreateMessage(serviceModel, messageModel)
+  CreateMessage(getCustomTelemetryClient, serviceModel, messageModel)
 );
 
 app.get("/api/v1/info", GetInfo(serviceModel));

--- a/lib/public_api_v1.ts
+++ b/lib/public_api_v1.ts
@@ -7,8 +7,6 @@ import { IContext } from "azure-function-express";
 
 import * as winston from "winston";
 
-import * as ApplicationInsights from "applicationinsights";
-
 import { setAppContext } from "./utils/middlewares/context_middleware";
 
 import { configureAzureContextTransport } from "./utils/logging";
@@ -130,10 +128,6 @@ const notificationStatusModel = new NotificationStatusModel(
 const storageConnectionString = getRequiredStringEnv("QueueStorageConnection");
 const blobService = createBlobService(storageConnectionString);
 
-// Setup ApplicationInsights
-
-const appInsightsClient = new ApplicationInsights.TelemetryClient();
-
 // Setup handlers
 
 const debugHandler = GetDebug(serviceModel);
@@ -173,7 +167,7 @@ app.get(
 );
 app.post(
   "/api/v1/messages/:fiscalcode",
-  CreateMessage(appInsightsClient, serviceModel, messageModel)
+  CreateMessage(serviceModel, messageModel)
 );
 
 app.get("/api/v1/info", GetInfo(serviceModel));

--- a/lib/utils/__tests__/application_insights.test.ts
+++ b/lib/utils/__tests__/application_insights.test.ts
@@ -1,3 +1,5 @@
+/* tslint:disable:no-any */
+
 jest.mock("applicationinsights");
 import * as applicationinsights from "applicationinsights";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
@@ -13,10 +15,11 @@ const AiConfiguration = {
 };
 
 describe("wrapCustomTelemetryClient", () => {
-  it("should return a telemetry client factory", () => {
+  it("should return a customized TelemetryClient with a TelemetryProcessor", () => {
+    const newTelemetryClient = new applicationinsights.TelemetryClient();
     const getTelemetryClient = wrapCustomTelemetryClient(
       false,
-      new applicationinsights.TelemetryClient()
+      newTelemetryClient
     );
     const telemetryClient = getTelemetryClient(
       {
@@ -24,9 +27,12 @@ describe("wrapCustomTelemetryClient", () => {
         operationParentId: "parentId" as NonEmptyString,
         serviceId: "serviceId" as NonEmptyString
       },
-      {}
+      { prop: "true" }
     );
+
     expect(telemetryClient).toBeInstanceOf(applicationinsights.TelemetryClient);
+    expect(telemetryClient).toBe(newTelemetryClient);
+    expect(telemetryClient.addTelemetryProcessor).toHaveBeenCalledTimes(1);
   });
   it("should change the default configuration when tracing is disable", () => {
     const configurationSpy = jest

--- a/lib/utils/__tests__/application_insights.test.ts
+++ b/lib/utils/__tests__/application_insights.test.ts
@@ -30,6 +30,25 @@ describe("wrapCustomTelemetryClient", () => {
       { prop: "true" }
     );
 
+    const mockEnv = { data: { baseData: { properties: {} } } } as any;
+
+    // tslint:disable-next-line:no-object-mutation
+    telemetryClient.context = {
+      keys: {
+        operationId: "operationId",
+        operationParentId: "oprationParentId",
+        userAccountId: "userAccountId"
+      } as any
+    } as any;
+
+    const processor = (telemetryClient.addTelemetryProcessor as jest.Mock).mock
+      .calls[0][0];
+
+    processor(mockEnv);
+
+    expect(mockEnv.data.baseData.properties.prop).toEqual("true");
+    expect(mockEnv.tags).toBeDefined();
+
     expect(telemetryClient).toBeInstanceOf(applicationinsights.TelemetryClient);
     expect(telemetryClient).toBe(newTelemetryClient);
     expect(telemetryClient.addTelemetryProcessor).toHaveBeenCalledTimes(1);

--- a/lib/utils/__tests__/application_insights.test.ts
+++ b/lib/utils/__tests__/application_insights.test.ts
@@ -1,0 +1,50 @@
+jest.mock("applicationinsights");
+import * as applicationinsights from "applicationinsights";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { wrapCustomTelemetryClient } from "../application_insights";
+
+const AiConfiguration = {
+  setAutoCollectConsole: jest.fn().mockReturnThis(),
+  setAutoCollectDependencies: jest.fn().mockReturnThis(),
+  setAutoCollectPerformance: jest.fn().mockReturnThis(),
+  setAutoCollectRequests: jest.fn().mockReturnThis(),
+  setInternalLogging: jest.fn().mockReturnThis(),
+  setUseDiskRetryCaching: jest.fn().mockReturnThis()
+};
+
+describe("wrapCustomTelemetryClient", () => {
+  it("should return a telemetry client factory", () => {
+    const getTelemetryClient = wrapCustomTelemetryClient(
+      false,
+      new applicationinsights.TelemetryClient()
+    );
+    const telemetryClient = getTelemetryClient(
+      {
+        operationId: "operationId" as NonEmptyString,
+        operationParentId: "parentId" as NonEmptyString,
+        serviceId: "serviceId" as NonEmptyString
+      },
+      {}
+    );
+    expect(telemetryClient).toBeInstanceOf(applicationinsights.TelemetryClient);
+  });
+  it("should change the default configuration when tracing is disable", () => {
+    const configurationSpy = jest
+      .spyOn(applicationinsights.Configuration, "setAutoCollectConsole")
+      .mockReturnValue(AiConfiguration);
+    const getTelemetryClient = wrapCustomTelemetryClient(
+      true,
+      new applicationinsights.TelemetryClient()
+    );
+    const telemetryClient = getTelemetryClient(
+      {
+        operationId: "operationId" as NonEmptyString,
+        operationParentId: "parentId" as NonEmptyString,
+        serviceId: "serviceId" as NonEmptyString
+      },
+      {}
+    );
+    expect(configurationSpy).toHaveBeenCalledTimes(1);
+    expect(telemetryClient).toBeInstanceOf(applicationinsights.TelemetryClient);
+  });
+});

--- a/lib/utils/application_insights.ts
+++ b/lib/utils/application_insights.ts
@@ -62,7 +62,7 @@ export function wrapCustomTelemetryClient(
   };
 }
 
-export type CustomTelemetryClient = ReturnType<
+export type CustomTelemetryClientFactory = ReturnType<
   typeof wrapCustomTelemetryClient
 >;
 

--- a/lib/utils/application_insights.ts
+++ b/lib/utils/application_insights.ts
@@ -4,6 +4,7 @@ import {
   EventData
 } from "applicationinsights/out/Declarations/Contracts";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { Millisecond } from "italia-ts-commons/lib/units";
 import { ServiceId } from "../api/definitions/ServiceId";
 
 export interface ITelemetryParams {
@@ -74,7 +75,8 @@ const MILLISEC_PER_SEC = 1e3;
  * from an initial time obtained calling process.hrtime().
  * Used when profiling code.
  */
-export function diffInMilliseconds(startHrtime: [number, number]): number {
+export function diffInMilliseconds(startHrtime: [number, number]): Millisecond {
   const diff = process.hrtime(startHrtime);
-  return diff[0] * MILLISEC_PER_SEC + diff[1] / NANOSEC_PER_MILLISEC;
+  return (diff[0] * MILLISEC_PER_SEC +
+    diff[1] / NANOSEC_PER_MILLISEC) as Millisecond;
 }

--- a/lib/utils/application_insights.ts
+++ b/lib/utils/application_insights.ts
@@ -1,0 +1,76 @@
+import * as ApplicationInsights from "applicationinsights";
+import {
+  Data,
+  EventData
+} from "applicationinsights/out/Declarations/Contracts";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { ServiceId } from "../api/definitions/ServiceId";
+
+export interface ITelemetryParams {
+  readonly operationId: NonEmptyString;
+  readonly operationParentId?: NonEmptyString;
+  readonly serviceId?: ServiceId;
+}
+
+/**
+ * A TelemetryClient instance cannot be shared between track calls
+ * as custom properties and tags (ie. operationId) are part
+ * of a mutable shared state attached to the instance.
+ *
+ * This method returns a TelemetryClient with a custom
+ * TelemetryProcessor that stores tags and properties
+ * before any call to track(); in this way the returned
+ * instance of the TelemetryClient can be shared safely.
+ */
+export function wrapCustomTelemetryClient(
+  isTracingDisabled: boolean,
+  client: ApplicationInsights.TelemetryClient
+): (
+  params: ITelemetryParams,
+  commonProperties?: Record<string, string>
+) => ApplicationInsights.TelemetryClient {
+  if (isTracingDisabled) {
+    // this won't disable manual calls to trackEvent / trackDependency
+    ApplicationInsights.Configuration.setAutoCollectConsole(false)
+      .setAutoCollectDependencies(false)
+      .setAutoCollectPerformance(false)
+      .setAutoCollectRequests(false)
+      .setInternalLogging(false)
+      // see https://stackoverflow.com/questions/49438235/application-insights-metric-in-aws-lambda/49441135#49441135
+      .setUseDiskRetryCaching(false);
+  }
+  return (params, commonProperties) => {
+    client.addTelemetryProcessor(env => {
+      // tslint:disable-next-line:no-object-mutation
+      env.tags = {
+        ...env.tags,
+        [client.context.keys.operationId]: params.operationId,
+        [client.context.keys.operationParentId]: params.operationParentId,
+        [client.context.keys.userAccountId]: params.serviceId
+      };
+      // cast needed due to https://github.com/Microsoft/ApplicationInsights-node.js/issues/392
+      const data = env.data as Data<EventData>;
+      // tslint:disable-next-line:no-object-mutation
+      data.baseData.properties = {
+        ...data.baseData.properties,
+        ...commonProperties
+      };
+      // return true to execute the following telemetry processor
+      return true;
+    });
+    return client;
+  };
+}
+
+const NANOSEC_PER_MILLISEC = 1e6;
+const MILLISEC_PER_SEC = 1e3;
+
+/**
+ * Small helper function that gets the difference in milliseconds
+ * from an initial time obtained calling process.hrtime().
+ * Used when profiling code.
+ */
+export function diffInMilliseconds(startHrtime: [number, number]): number {
+  const diff = process.hrtime(startHrtime);
+  return diff[0] * MILLISEC_PER_SEC + diff[1] / NANOSEC_PER_MILLISEC;
+}

--- a/lib/utils/application_insights.ts
+++ b/lib/utils/application_insights.ts
@@ -62,6 +62,10 @@ export function wrapCustomTelemetryClient(
   };
 }
 
+export type CustomTelemetryClient = ReturnType<
+  typeof wrapCustomTelemetryClient
+>;
+
 const NANOSEC_PER_MILLISEC = 1e6;
 const MILLISEC_PER_SEC = 1e3;
 


### PR DESCRIPTION
Added tracking of:

for each queue handler:
- number of TransientErrors (retry) + time elapsed from message creation
- number of PermanentErrors + time elapsed from message creation
- number of Sucessful processing + time elapsed from message creation

- duration of calls to email provider (and failures)
- duration of calls to webhook endpoint (and failures)

that would be useful to monitor queues lenght as well, but that would require a dedicated function.
