### PR TITLE
[#157917582] return transient error in case the API proxy returns 5xx HTTP status

### DIFF
--- a/lib/__tests__/webhook_queue_handler.test.ts
+++ b/lib/__tests__/webhook_queue_handler.test.ts
@@ -178,6 +178,34 @@ describe("sendToWebhook", () => {
       expect(isTransient(ret.value)).toBeTruthy();
     }
   });
+  it("should return a transient error in case the webhook returns HTTP status 5xx", async () => {
+    const sendMock = jest.fn();
+    sendMock.mockImplementation(() => {
+      return Promise.reject({ status: 555 });
+    });
+    // tslint:disable-next-line:no-object-mutation
+    (superagent as any).Request.prototype.send = sendMock;
+    const ret = await sendToWebhook({} as any, {} as any, {} as any);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(isLeft(ret)).toBeTruthy();
+    if (isLeft(ret)) {
+      expect(isTransient(ret.value)).toBeTruthy();
+    }
+  });
+  it("should return a permanent error in case the webhook returns HTTP status 4xx", async () => {
+    const sendMock = jest.fn();
+    sendMock.mockImplementation(() => {
+      return Promise.reject({ status: 444 });
+    });
+    // tslint:disable-next-line:no-object-mutation
+    (superagent as any).Request.prototype.send = sendMock;
+    const ret = await sendToWebhook({} as any, {} as any, {} as any);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(isLeft(ret)).toBeTruthy();
+    if (isLeft(ret)) {
+      expect(isTransient(ret.value)).toBeFalsy();
+    }
+  });
 });
 
 describe("handleNotification", () => {

--- a/lib/webhook_queue_handler.ts
+++ b/lib/webhook_queue_handler.ts
@@ -198,7 +198,7 @@ export async function sendToWebhook(
           err.timeout
             ? TransientError(`Timeout calling API Proxy`)
             : // when the server returns an HTTP 5xx error
-              err.status && Math.floor(err.status / 100) === 5
+              err.status && err.status % 500 < 100
               ? TransientError(`Transient error calling API proxy: ${errorMsg}`)
               : // when the server returns some other type of HTTP error
                 PermanentError(`Permanent error calling API Proxy: ${errorMsg}`)


### PR DESCRIPTION
trigger a retry in case of HTTP 5xx errors. 

added tests