### PR TITLE
[#158006232] forces the use of a partitionKey during queries

### DIFF
--- a/lib/created_message_queue_handler.ts
+++ b/lib/created_message_queue_handler.ts
@@ -32,10 +32,15 @@ import { NewMessageDefaultAddresses } from "./api/definitions/NewMessageDefaultA
 import { getRequiredStringEnv } from "./utils/env";
 
 import { CreatedMessageEvent } from "./models/created_message_event";
-import { MessageModel, NewMessageWithContent } from "./models/message";
+import {
+  MESSAGE_COLLECTION_NAME,
+  MessageModel,
+  NewMessageWithContent
+} from "./models/message";
 import {
   createNewNotification,
   NewNotification,
+  NOTIFICATION_COLLECTION_NAME,
   NotificationAddressSourceEnum,
   NotificationChannelEmail,
   NotificationModel
@@ -43,6 +48,7 @@ import {
 import { NotificationEvent } from "./models/notification_event";
 import {
   IProfileBlockedInboxOrChannels,
+  PROFILE_COLLECTION_NAME,
   ProfileModel,
   RetrievedProfile
 } from "./models/profile";
@@ -78,15 +84,15 @@ const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
 const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
 const profilesCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,
-  "profiles"
+  PROFILE_COLLECTION_NAME
 );
 const messagesCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,
-  "messages"
+  MESSAGE_COLLECTION_NAME
 );
 const notificationsCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,
-  "notifications"
+  NOTIFICATION_COLLECTION_NAME
 );
 const messageStatusCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,

--- a/lib/emailnotifications_queue_handler.ts
+++ b/lib/emailnotifications_queue_handler.ts
@@ -32,7 +32,11 @@ import * as HtmlToText from "html-to-text";
 import { MessageBodyMarkdown } from "./api/definitions/MessageBodyMarkdown";
 
 import { CreatedMessageEventSenderMetadata } from "./models/created_message_sender_metadata";
-import { EmailNotification, NotificationModel } from "./models/notification";
+import {
+  EmailNotification,
+  NOTIFICATION_COLLECTION_NAME,
+  NotificationModel
+} from "./models/notification";
 import { NotificationEvent } from "./models/notification_event";
 
 import { markdownToHtml } from "./utils/markdown";
@@ -74,7 +78,7 @@ const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
 
 const notificationsCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,
-  "notifications"
+  NOTIFICATION_COLLECTION_NAME
 );
 
 const notificationStatusCollectionUrl = documentDbUtils.getCollectionUri(

--- a/lib/models/__tests__/message.test.ts
+++ b/lib/models/__tests__/message.test.ts
@@ -15,6 +15,7 @@ import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { fromNullable, none, some } from "fp-ts/lib/Option";
 
 import {
+  MESSAGE_COLLECTION_NAME,
   MessageModel,
   NewMessageWithContent,
   RetrievedMessageWithContent
@@ -31,7 +32,7 @@ const MESSAGE_CONTAINER_NAME = "message-content" as NonEmptyString;
 const aDatabaseUri = DocumentDbUtils.getDatabaseUri("mockdb" as NonEmptyString);
 const aMessagesCollectionUrl = DocumentDbUtils.getCollectionUri(
   aDatabaseUri,
-  "messages"
+  MESSAGE_COLLECTION_NAME
 );
 
 const aMessageBodyMarkdown = "test".repeat(80) as MessageBodyMarkdown;

--- a/lib/models/__tests__/notification.test.ts
+++ b/lib/models/__tests__/notification.test.ts
@@ -14,6 +14,7 @@ import { EmailAddress } from "../../api/definitions/EmailAddress";
 import { NotificationChannelEnum } from "../../api/definitions/NotificationChannel";
 import {
   NewNotification,
+  NOTIFICATION_COLLECTION_NAME,
   NotificationAddressSourceEnum,
   NotificationModel,
   RetrievedNotification
@@ -22,7 +23,7 @@ import {
 const aDatabaseUri = DocumentDbUtils.getDatabaseUri("mockdb" as NonEmptyString);
 const aNotificationsCollectionUri = DocumentDbUtils.getCollectionUri(
   aDatabaseUri,
-  "notifications"
+  NOTIFICATION_COLLECTION_NAME
 );
 
 const aFiscalCode = "FRLFRC74E04B157I" as FiscalCode;

--- a/lib/models/__tests__/profile.test.ts
+++ b/lib/models/__tests__/profile.test.ts
@@ -12,12 +12,17 @@ import { NonNegativeNumber } from "italia-ts-commons/lib/numbers";
 import { EmailString, NonEmptyString } from "italia-ts-commons/lib/strings";
 import { FiscalCode } from "../../api/definitions/FiscalCode";
 
-import { Profile, ProfileModel, RetrievedProfile } from "../profile";
+import {
+  Profile,
+  PROFILE_COLLECTION_NAME,
+  ProfileModel,
+  RetrievedProfile
+} from "../profile";
 
 const aDatabaseUri = DocumentDbUtils.getDatabaseUri("mockdb" as NonEmptyString);
 const profilesCollectionUrl = DocumentDbUtils.getCollectionUri(
   aDatabaseUri,
-  "profiles"
+  PROFILE_COLLECTION_NAME
 );
 
 const aFiscalCode = "FRLFRC74E04B157I" as FiscalCode;

--- a/lib/models/message.ts
+++ b/lib/models/message.ts
@@ -22,6 +22,9 @@ import { TimeToLiveSeconds } from "../api/definitions/TimeToLiveSeconds";
 import { getBlobAsText, upsertBlobFromObject } from "../utils/azure_storage";
 import { iteratorToArray } from "../utils/documentdb";
 
+export const MESSAGE_COLLECTION_NAME = "messages";
+export const MESSAGE_MODEL_PK_FIELD = "fiscalCode";
+
 const MESSAGE_BLOB_STORAGE_SUFFIX = ".json";
 
 const MessageBase = t.interface(
@@ -246,15 +249,20 @@ export class MessageModel extends DocumentDbModel<
   public findMessages(
     fiscalCode: FiscalCode
   ): DocumentDbUtils.IResultIterator<RetrievedMessageWithContent> {
-    return DocumentDbUtils.queryDocuments(this.dbClient, this.collectionUri, {
-      parameters: [
-        {
-          name: "@fiscalCode",
-          value: fiscalCode
-        }
-      ],
-      query: "SELECT * FROM messages m WHERE (m.fiscalCode = @fiscalCode)"
-    });
+    return DocumentDbUtils.queryDocuments(
+      this.dbClient,
+      this.collectionUri,
+      {
+        parameters: [
+          {
+            name: "@fiscalCode",
+            value: fiscalCode
+          }
+        ],
+        query: `SELECT * FROM m WHERE (m.${MESSAGE_MODEL_PK_FIELD} = @fiscalCode)`
+      },
+      fiscalCode
+    );
   }
 
   /**

--- a/lib/models/message_status.ts
+++ b/lib/models/message_status.ts
@@ -164,6 +164,8 @@ export class MessageStatusModel extends DocumentDbModelVersioned<
   ): Promise<Either<DocumentDb.QueryError, Option<RetrievedMessageStatus>>> {
     return super.findLastVersionByModelId(
       MESSAGE_STATUS_MODEL_ID_FIELD,
+      messageId,
+      MESSAGE_STATUS_MODEL_PK_FIELD,
       messageId
     );
   }

--- a/lib/models/notification.ts
+++ b/lib/models/notification.ts
@@ -23,6 +23,9 @@ import { HttpsUrl } from "../api/definitions/HttpsUrl";
 import { NotificationChannelEnum } from "../api/definitions/NotificationChannel";
 import { ObjectIdGenerator } from "../utils/strings";
 
+export const NOTIFICATION_COLLECTION_NAME = "notifications";
+export const NOTIFICATION_MODEL_PK_FIELD = "messageId";
+
 /**
  * All possible sources that can provide the address of the recipient.
  */
@@ -190,14 +193,19 @@ export class NotificationModel extends DocumentDbModel<
   public findNotificationForMessage(
     messageId: string
   ): Promise<Either<DocumentDb.QueryError, Option<RetrievedNotification>>> {
-    return DocumentDbUtils.queryOneDocument(this.dbClient, this.collectionUri, {
-      parameters: [
-        {
-          name: "@messageId",
-          value: messageId
-        }
-      ],
-      query: "SELECT * FROM notifications n WHERE (n.messageId = @messageId)"
-    });
+    return DocumentDbUtils.queryOneDocument(
+      this.dbClient,
+      this.collectionUri,
+      {
+        parameters: [
+          {
+            name: "@messageId",
+            value: messageId
+          }
+        ],
+        query: `SELECT * FROM n WHERE (n.${NOTIFICATION_MODEL_PK_FIELD} = @messageId)`
+      },
+      messageId
+    );
   }
 }

--- a/lib/models/profile.ts
+++ b/lib/models/profile.ts
@@ -24,6 +24,9 @@ import { PreferredLanguages } from "../api/definitions/PreferredLanguages";
 import { ServiceId } from "../api/definitions/ServiceId";
 import { fiscalCodeToModelId } from "../utils/conversions";
 
+export const PROFILE_COLLECTION_NAME = "profiles";
+export const PROFILE_MODEL_PK_FIELD = "fiscalCode";
+
 const ProfileBlockedInboxOrChannels = t.dictionary(
   ServiceId,
   readonlySetType(BlockedInboxOrChannel, "ProfileBlockedInboxOrChannel"),
@@ -162,6 +165,11 @@ export class ProfileModel extends DocumentDbModelVersioned<
   public findOneProfileByFiscalCode(
     fiscalCode: FiscalCode
   ): Promise<Either<DocumentDb.QueryError, Option<RetrievedProfile>>> {
-    return super.findLastVersionByModelId("fiscalCode", fiscalCode);
+    return super.findLastVersionByModelId(
+      PROFILE_MODEL_PK_FIELD,
+      fiscalCode,
+      PROFILE_MODEL_PK_FIELD,
+      fiscalCode
+    );
   }
 }

--- a/lib/models/service.ts
+++ b/lib/models/service.ts
@@ -23,6 +23,9 @@ import { nonEmptyStringToModelId } from "../utils/conversions";
 
 import { readonlySetType, tag } from "italia-ts-commons/lib/types";
 
+export const SERVICE_COLLECTION_NAME = "services";
+export const SERVICE_MODEL_PK_FIELD = "serviceId";
+
 /**
  * Base interface for Service objects
  */
@@ -170,6 +173,11 @@ export class ServiceModel extends DocumentDbModelVersioned<
   public findOneByServiceId(
     serviceId: NonEmptyString
   ): Promise<Either<DocumentDb.QueryError, Option<RetrievedService>>> {
-    return super.findLastVersionByModelId("serviceId", serviceId);
+    return super.findLastVersionByModelId(
+      SERVICE_MODEL_PK_FIELD,
+      serviceId,
+      SERVICE_MODEL_PK_FIELD,
+      serviceId
+    );
   }
 }

--- a/lib/public_api_v1.ts
+++ b/lib/public_api_v1.ts
@@ -19,10 +19,13 @@ import * as documentDbUtils from "./utils/documentdb";
 
 import { createAzureFunctionHandler } from "azure-function-express";
 
-import { MessageModel } from "./models/message";
-import { NotificationModel } from "./models/notification";
-import { ProfileModel } from "./models/profile";
-import { ServiceModel } from "./models/service";
+import { MESSAGE_COLLECTION_NAME, MessageModel } from "./models/message";
+import {
+  NOTIFICATION_COLLECTION_NAME,
+  NotificationModel
+} from "./models/notification";
+import { PROFILE_COLLECTION_NAME, ProfileModel } from "./models/profile";
+import { SERVICE_COLLECTION_NAME, ServiceModel } from "./models/service";
 
 import { GetDebug } from "./controllers/debug";
 import { GetInfo } from "./controllers/info";
@@ -61,7 +64,7 @@ const messageContainerName = getRequiredStringEnv("MESSAGE_CONTAINER_NAME");
 const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
 const messagesCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,
-  "messages"
+  MESSAGE_COLLECTION_NAME
 );
 const messageStatusCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,
@@ -69,15 +72,15 @@ const messageStatusCollectionUrl = documentDbUtils.getCollectionUri(
 );
 const profilesCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,
-  "profiles"
+  PROFILE_COLLECTION_NAME
 );
 const servicesCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,
-  "services"
+  SERVICE_COLLECTION_NAME
 );
 const notificationsCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,
-  "notifications"
+  NOTIFICATION_COLLECTION_NAME
 );
 const notificationsStatusCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,

--- a/lib/utils/__tests__/documentdb.test.ts
+++ b/lib/utils/__tests__/documentdb.test.ts
@@ -258,12 +258,14 @@ describe("queryDocuments", () => {
     const iterator = DocumentDbUtils.queryDocuments(
       (clientMock as any) as DocumentDb.DocumentClient,
       collectionUriFixture,
-      "QUERY"
+      "QUERY",
+      "PARTITIONKEY"
     );
     expect(clientMock.queryDocuments).toHaveBeenCalledTimes(1);
     expect(clientMock.queryDocuments).toBeCalledWith(
       collectionUriFixture.uri,
-      "QUERY"
+      "QUERY",
+      { partitionKey: "PARTITIONKEY" }
     );
     const result = await iterator.executeNext();
     expect(iteratorMock.executeNext).toBeCalled();
@@ -284,12 +286,14 @@ describe("queryDocuments", () => {
     const iterator = DocumentDbUtils.queryDocuments(
       (clientMock as any) as DocumentDb.DocumentClient,
       collectionUriFixture,
-      "QUERY"
+      "QUERY",
+      "PARTITIONKEY"
     );
     expect(clientMock.queryDocuments).toHaveBeenCalledTimes(1);
     expect(clientMock.queryDocuments).toBeCalledWith(
       collectionUriFixture.uri,
-      "QUERY"
+      "QUERY",
+      { partitionKey: "PARTITIONKEY" }
     );
     const result = await iterator.executeNext();
     expect(iteratorMock.executeNext).toBeCalled();
@@ -319,12 +323,14 @@ describe("queryOneDocument", () => {
     const result = await DocumentDbUtils.queryOneDocument(
       (clientMock as any) as DocumentDb.DocumentClient,
       collectionUriFixture,
-      "QUERY"
+      "QUERY",
+      "PARTITIONKEY"
     );
     expect(clientMock.queryDocuments).toHaveBeenCalledTimes(1);
     expect(clientMock.queryDocuments).toBeCalledWith(
       collectionUriFixture.uri,
-      "QUERY"
+      "QUERY",
+      { partitionKey: "PARTITIONKEY" }
     );
     expect(iteratorMock.executeNext).toBeCalled();
     expect(isRight(result)).toBeTruthy();
@@ -344,12 +350,14 @@ describe("queryOneDocument", () => {
     const result = await DocumentDbUtils.queryOneDocument(
       (clientMock as any) as DocumentDb.DocumentClient,
       collectionUriFixture,
-      "QUERY"
+      "QUERY",
+      "PARTITIONKEY"
     );
     expect(clientMock.queryDocuments).toHaveBeenCalledTimes(1);
     expect(clientMock.queryDocuments).toBeCalledWith(
       collectionUriFixture.uri,
-      "QUERY"
+      "QUERY",
+      { partitionKey: "PARTITIONKEY" }
     );
     expect(iteratorMock.executeNext).toBeCalled();
     expect(isRight(result)).toBeTruthy();
@@ -368,12 +376,14 @@ describe("queryOneDocument", () => {
     const result = await DocumentDbUtils.queryOneDocument(
       (clientMock as any) as DocumentDb.DocumentClient,
       collectionUriFixture,
-      "QUERY"
+      "QUERY",
+      "PARTITIONKEY"
     );
     expect(clientMock.queryDocuments).toHaveBeenCalledTimes(1);
     expect(clientMock.queryDocuments).toBeCalledWith(
       collectionUriFixture.uri,
-      "QUERY"
+      "QUERY",
+      { partitionKey: "PARTITIONKEY" }
     );
     expect(iteratorMock.executeNext).toBeCalled();
     expect(isLeft(result)).toBeTruthy();

--- a/lib/utils/documentdb.ts
+++ b/lib/utils/documentdb.ts
@@ -273,9 +273,12 @@ export function readDocument<T>(
 export function queryDocuments<T>(
   client: DocumentDb.DocumentClient,
   collectionUri: IDocumentDbCollectionUri,
-  query: DocumentDb.DocumentQuery
+  query: DocumentDb.DocumentQuery,
+  partitionKey: string
 ): IResultIterator<T & DocumentDb.RetrievedDocument> {
-  const documentIterator = client.queryDocuments(collectionUri.uri, query);
+  const documentIterator = client.queryDocuments(collectionUri.uri, query, {
+    partitionKey
+  });
   return {
     executeNext: () => {
       return new Promise(resolve => {
@@ -325,12 +328,18 @@ export function queryDocuments<T>(
 export function queryOneDocument<T>(
   client: DocumentDb.DocumentClient,
   collectionUrl: IDocumentDbCollectionUri,
-  query: DocumentDb.DocumentQuery
+  query: DocumentDb.DocumentQuery,
+  partitionKey: string
 ): Promise<
   Either<DocumentDb.QueryError, Option<T & DocumentDb.RetrievedDocument>>
 > {
   // get a result iterator for the query
-  const iterator = queryDocuments<T>(client, collectionUrl, query);
+  const iterator = queryDocuments<T>(
+    client,
+    collectionUrl,
+    query,
+    partitionKey
+  );
   return new Promise((resolve, reject) => {
     // fetch the first batch of results, since we're looking for just the
     // first result, we should go no further

--- a/lib/utils/documentdb_model_versioned.ts
+++ b/lib/utils/documentdb_model_versioned.ts
@@ -214,7 +214,7 @@ export abstract class DocumentDbModelVersioned<
         ],
         // do not use ${collectionName} here as it may contain special characters
         query: `SELECT TOP 1 * FROM m WHERE (m.${modelIdField} = @modelId
-          AND m.${partitionKeyField} = @partitionKey ORDER BY m.version DESC`
+          AND m.${partitionKeyField} = @partitionKey) ORDER BY m.version DESC`
       },
       partitionKeyValue
     );

--- a/lib/utils/documentdb_model_versioned.ts
+++ b/lib/utils/documentdb_model_versioned.ts
@@ -195,8 +195,8 @@ export abstract class DocumentDbModelVersioned<
   >(
     modelIdField: K1,
     modelIdValue: V,
-    partitionKeyField?: K2,
-    partitionKeyValue?: string
+    partitionKeyField: K2,
+    partitionKeyValue: string
   ): Promise<Either<DocumentDb.QueryError, Option<TR>>> {
     const errorOrMaybeDocument = await DocumentDbUtils.queryOneDocument(
       this.dbClient,
@@ -213,10 +213,10 @@ export abstract class DocumentDbModelVersioned<
           }
         ],
         // do not use ${collectionName} here as it may contain special characters
-        query: `SELECT TOP 1 * FROM m WHERE (m.${modelIdField} = @modelId ${
-          partitionKeyField ? `AND m.${partitionKeyField} = @partitionKey` : ``
-        }) ORDER BY m.version DESC`
-      }
+        query: `SELECT TOP 1 * FROM m WHERE (m.${modelIdField} = @modelId
+          AND m.${partitionKeyField} = @partitionKey ORDER BY m.version DESC`
+      },
+      partitionKeyValue
     );
 
     if (

--- a/lib/webhook_queue_handler.ts
+++ b/lib/webhook_queue_handler.ts
@@ -27,7 +27,11 @@ import { getRequiredStringEnv } from "./utils/env";
 
 import { IContext } from "azure-functions-types";
 
-import { NotificationModel, WebhookNotification } from "./models/notification";
+import {
+  NOTIFICATION_COLLECTION_NAME,
+  NotificationModel,
+  WebhookNotification
+} from "./models/notification";
 import { NotificationEvent } from "./models/notification_event";
 
 import {
@@ -68,7 +72,7 @@ const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
 
 const notificationsCollectionUrl = documentDbUtils.getCollectionUri(
   documentDbDatabaseUrl,
-  "notifications"
+  NOTIFICATION_COLLECTION_NAME
 );
 
 const notificationStatusCollectionUrl = documentDbUtils.getCollectionUri(


### PR DESCRIPTION
Force all CosmosDb queries to provide a partitionKey.

This is important as the current implementation of iteratorToArray (and so ResponseSuccessIterator) swallows any error regarding cross partition queries.