### PR TITLE
[#157928027] add a function to monitor queue length 

### DIFF
--- a/QueueMonitor/function.json
+++ b/QueueMonitor/function.json
@@ -3,7 +3,7 @@
   "disabled": false,
   "bindings": [
     {
-      "schedule": "*/30 * * * * *",
+      "schedule": "0 * * * * *",
       "name": "myTimer",
       "type": "timerTrigger",
       "direction": "in"

--- a/QueueMonitor/function.json
+++ b/QueueMonitor/function.json
@@ -3,7 +3,7 @@
   "disabled": false,
   "bindings": [
     {
-      "schedule": "0 */1 * * * *",
+      "schedule": "*/30 * * * * *",
       "name": "myTimer",
       "type": "timerTrigger",
       "direction": "in"

--- a/host.json
+++ b/host.json
@@ -19,7 +19,8 @@
     "AdminApi",
     "CreatedMessageQueueHandler",
     "EmailNotificationsQueueHandler",
-    "WebhookNotificationsQueueHandler"
+    "WebhookNotificationsQueueHandler",
+    "QueueMonitor"
   ],
   "tracing": {
     "consoleLevel": "verbose",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,5 +5,6 @@ export = {
     .index,
   Openapi: require("./openapi").index,
   PublicApiV1: require("./public_api_v1").index,
+  QueueMonitor: require("./queue_monitor").index,
   WebhookNotificationsQueueHandler: require("./webhook_queue_handler").index
 };

--- a/lib/queue_monitor.ts
+++ b/lib/queue_monitor.ts
@@ -17,6 +17,11 @@ const isProduction = process.env.NODE_ENV === "production";
 
 const appInsightsClient = new TelemetryClient();
 
+// needed otherwise AI will wait for the batching loop to end
+// see https://github.com/Microsoft/ApplicationInsights-node.js/issues/390
+// tslint:disable-next-line:no-object-mutation
+appInsightsClient.config.maxBatchSize = 1;
+
 /**
  * A function to store the length of Azure Storage Queues
  * into Application Insights Metrics.
@@ -51,9 +56,6 @@ export function index(context: IContext): void {
         name: `queue.length.${queueName}`,
         value: result.approximateMessageCount || 0
       });
-      // needed otherwise AI will wait for the batching loop to end
-      // see https://github.com/Microsoft/ApplicationInsights-node.js/issues/390
-      appInsightsClient.flush();
     })
   );
 }

--- a/lib/queue_monitor.ts
+++ b/lib/queue_monitor.ts
@@ -17,7 +17,17 @@ const isProduction = process.env.NODE_ENV === "production";
 
 const appInsightsClient = new TelemetryClient();
 
-export async function index(context: IContext): Promise<void> {
+/**
+ * A function to store the length of Azure Storage Queues
+ * into Application Insights Metrics.
+ *
+ * To query these values in the Analytics panel type:
+ *
+ * customMetrics
+ *   | where * has  "queue.length"
+ *   | order by timestamp desc
+ */
+export function index(context: IContext): void {
   const logLevel = isProduction ? "info" : "debug";
   configureAzureContextTransport(context, winston, logLevel);
 
@@ -28,11 +38,11 @@ export async function index(context: IContext): Promise<void> {
   ].map(queueName =>
     queueService.getQueueMetadata(queueName, (error, result) => {
       if (error) {
-        winston.error("Error in queue monitor: %s (%s)", error, queueName);
+        winston.error("Error in QueueMonitor: %s (%s)", error, queueName);
         return;
       }
       winston.debug(
-        "Queue %s count: %d",
+        "Queue '%s' length is: %d",
         queueName,
         result.approximateMessageCount
       );

--- a/lib/queue_monitor.ts
+++ b/lib/queue_monitor.ts
@@ -51,6 +51,9 @@ export function index(context: IContext): void {
         name: `queue.length.${queueName}`,
         value: result.approximateMessageCount || 0
       });
+      // needed otherwise AI will wait for the batching loop to end
+      // see https://github.com/Microsoft/ApplicationInsights-node.js/issues/390
+      appInsightsClient.flush();
     })
   );
 }

--- a/lib/queue_monitor.ts
+++ b/lib/queue_monitor.ts
@@ -27,6 +27,7 @@ const appInsightsClient = new TelemetryClient();
  *   | where * has  "queue.length"
  *   | order by timestamp desc
  */
+/* istanbul ignore next */
 export function index(context: IContext): void {
   const logLevel = isProduction ? "info" : "debug";
   configureAzureContextTransport(context, winston, logLevel);
@@ -35,7 +36,7 @@ export function index(context: IContext): void {
     EMAIL_NOTIFICATION_QUEUE_NAME,
     WEBHOOK_NOTIFICATION_QUEUE_NAME,
     MESSAGE_QUEUE_NAME
-  ].map(queueName =>
+  ].forEach(queueName =>
     queueService.getQueueMetadata(queueName, (error, result) => {
       if (error) {
         winston.error("Error in QueueMonitor: %s (%s)", error, queueName);

--- a/lib/queue_monitor.ts
+++ b/lib/queue_monitor.ts
@@ -3,7 +3,6 @@ import * as winston from "winston";
 import { TelemetryClient } from "applicationinsights";
 import { IContext } from "azure-functions-types";
 import { createQueueService } from "azure-storage";
-import { isLeft } from "fp-ts/lib/Either";
 import { MESSAGE_QUEUE_NAME } from "./created_message_queue_handler";
 import { EMAIL_NOTIFICATION_QUEUE_NAME } from "./emailnotifications_queue_handler";
 import { getQueueMetadata } from "./utils/azure_queues";

--- a/lib/utils/azure_queues.ts
+++ b/lib/utils/azure_queues.ts
@@ -5,7 +5,7 @@ import * as winston from "winston";
 
 import { QueueService } from "azure-storage";
 
-import { Either } from "fp-ts/lib/Either";
+import { Either, left, right } from "fp-ts/lib/Either";
 import { Option, some } from "fp-ts/lib/Option";
 import {
   isTransient,
@@ -211,4 +211,22 @@ export async function handleQueueProcessingFailure(
       // do not catch here, let it throw
     );
   }
+}
+
+/**
+ * Promisify queueService.getQueueMetadata
+ */
+/* istanbul ignore next */
+export function getQueueMetadata(
+  queueService: QueueService,
+  queueName: string
+): Promise<Either<Error, QueueService.QueueResult>> {
+  return new Promise(resolve =>
+    queueService.getQueueMetadata(queueName, (error, result) => {
+      if (error) {
+        return resolve(left<Error, QueueService.QueueResult>(error));
+      }
+      return resolve(right<Error, QueueService.QueueResult>(result));
+    })
+  );
 }


### PR DESCRIPTION
Runs every 30 seconds to store queue length into Application Insights metrics:

![image](https://user-images.githubusercontent.com/148224/40881678-2062339a-66cd-11e8-8f81-1d0cded023ca.png)
