### PR TITLE
[#157244655] send welcome message

### DIFF
--- a/ProfileEventsQueueHandler/function.json
+++ b/ProfileEventsQueueHandler/function.json
@@ -1,0 +1,14 @@
+{
+  "scriptFile": "../lib/index.js",
+  "disabled": false,
+  "bindings": [
+    {
+      "type": "queueTrigger",
+      "direction": "in",
+      "name": "profileEvent",
+      "queueName": "profileevents",
+      "connection": "QueueStorageConnection"
+    }
+  ],
+  "entryPoint": "ProfileEventsQueueHandler"
+ }

--- a/PublicApiV1/function.json
+++ b/PublicApiV1/function.json
@@ -20,11 +20,18 @@
   },
   {
    "type": "queue",
-   "direction": "out",
-   "name": "createdMessage",
-   "queueName": "createdmessages",
-   "connection": "QueueStorageConnection"
+    "direction": "out",
+    "name": "createdMessage",
+    "queueName": "createdmessages",
+    "connection": "QueueStorageConnection"
+   },
+   {
+    "type": "queue",
+    "direction": "out",
+    "name": "profileEvent",
+    "queueName": "profileevents",
+    "connection": "QueueStorageConnection"
   }
- ],
+],
  "entryPoint": "PublicApiV1"
 }

--- a/api/public_api_v1.yaml
+++ b/api/public_api_v1.yaml
@@ -58,7 +58,7 @@ info:
         add a reminder when receiving the message. The format for all
         dates is [ISO8601](https://it.wikipedia.org/wiki/ISO_8601) with time 
         information and UTC timezone (ie. "2018-10-13T00:00:00.000Z").
-
+        
     ## Allowed Markdown formatting
 
     Not all Markdown formatting is currently available. Currently you can use
@@ -299,6 +299,12 @@ paths:
       responses:
         '201':
           description: Message created.
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                description: The identifier of the created message.
           headers:
             Location:
               type: string

--- a/host.json
+++ b/host.json
@@ -21,7 +21,7 @@
     "EmailNotificationsQueueHandler",
     "WebhookNotificationsQueueHandler",
     "QueueMonitor",
-    "ProfileEventsHandler"
+    "ProfileEventsQueueHandler"
   ],
   "tracing": {
     "consoleLevel": "verbose",

--- a/host.json
+++ b/host.json
@@ -20,7 +20,8 @@
     "CreatedMessageQueueHandler",
     "EmailNotificationsQueueHandler",
     "WebhookNotificationsQueueHandler",
-    "QueueMonitor"
+    "QueueMonitor",
+    "ProfileEventsHandler"
   ],
   "tracing": {
     "consoleLevel": "verbose",

--- a/lib/controllers/__tests__/profiles.test.ts
+++ b/lib/controllers/__tests__/profiles.test.ts
@@ -202,6 +202,7 @@ describe("UpsertProfile", () => {
     const upsertProfileHandler = UpsertProfileHandler(profileModelMock as any);
 
     const response = await upsertProfileHandler(
+      { bindings: {} } as any,
       anAzureAuthorization,
       undefined as any,
       undefined as any,
@@ -255,6 +256,7 @@ describe("UpsertProfile", () => {
     };
 
     const response = await upsertProfileHandler(
+      { bindings: {} } as any,
       anAzureAuthorization,
       undefined as any,
       undefined as any,
@@ -294,6 +296,7 @@ describe("UpsertProfile", () => {
     };
 
     const response = await upsertProfileHandler(
+      { bindings: {} } as any,
       anAzureAuthorization,
       undefined as any,
       undefined as any,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,7 @@ export = {
   EmailNotificationsQueueHandler: require("./emailnotifications_queue_handler")
     .index,
   Openapi: require("./openapi").index,
+  ProfileEventsQueueHandler: require("./profile_events_queue_handler").index,
   PublicApiV1: require("./public_api_v1").index,
   QueueMonitor: require("./queue_monitor").index,
   WebhookNotificationsQueueHandler: require("./webhook_queue_handler").index

--- a/lib/profile_events_queue_handler.ts
+++ b/lib/profile_events_queue_handler.ts
@@ -72,7 +72,7 @@ export async function index(
     JSON.stringify(event)
   );
 
-  const url = adminApiUrl + "/api/v1/messages/" + event.fiscalCode;
+  const url = `${adminApiUrl}/api/v1/messages/${event.fiscalCode}`;
 
   const hasJustEnabledInbox =
     event.newProfile.is_inbox_enabled === true &&
@@ -94,7 +94,7 @@ export async function index(
     });
 
     // TODO: schedule retries
-    sendWelcomeMessage(url, adminApiKey, newMessage).then(response => {
+    await sendWelcomeMessage(url, adminApiKey, newMessage).then(response => {
       winston.debug(
         `ProfileEventsQueueHandler|Welcome message sent to ${
           event.fiscalCode

--- a/lib/profile_events_queue_handler.ts
+++ b/lib/profile_events_queue_handler.ts
@@ -32,13 +32,13 @@ const adminApiKey = getRequiredStringEnv("ADMIN_API_KEY");
 // TODO: decide text for welcome message
 // TODO: switch text based on user's preferred_language
 const createWelcomeMessageMarkdown = (profile: ExtendedProfile) =>
-  `Hello new user ${profile.email}
+  `Hello new user ${profile.email || ""}
 
   We welcome you to the digital citizenship API program  
   This is a welcome message to test the system (if it works)`;
 
 const createWelcomeMessageSubject = (profile: ExtendedProfile) =>
-  `Welcome new user ${profile.email}`;
+  `Welcome new user ${profile.email || ""}`;
 
 const ContextWithBindings = t.exact(
   t.interface({

--- a/lib/profile_events_queue_handler.ts
+++ b/lib/profile_events_queue_handler.ts
@@ -94,12 +94,11 @@ export async function index(
     });
 
     // TODO: schedule retries
-    await sendWelcomeMessage(url, adminApiKey, newMessage).then(response => {
-      winston.debug(
-        `ProfileEventsQueueHandler|Welcome message sent to ${
-          event.fiscalCode
-        } (response status=${response.status})`
-      );
-    });
+    const response = await sendWelcomeMessage(url, adminApiKey, newMessage);
+    winston.debug(
+      `ProfileEventsQueueHandler|Welcome message sent to ${
+        event.fiscalCode
+      } (response status=${response.status})`
+    );
   }
 }

--- a/lib/profile_events_queue_handler.ts
+++ b/lib/profile_events_queue_handler.ts
@@ -1,0 +1,107 @@
+/**
+ * This function (a queue handler) processes any event
+ * triggered when a user's profile is created or updated.
+ *
+ */
+import * as t from "io-ts";
+import * as winston from "winston";
+
+import { IContext } from "azure-functions-types";
+import {
+  IProfileCreatedEvent,
+  IProfileUpdatedEvent
+} from "./controllers/profiles";
+import { configureAzureContextTransport } from "./utils/logging";
+
+import { readableReport } from "italia-ts-commons/lib/reporters";
+import * as request from "superagent";
+import { ExtendedProfile } from "./api/definitions/ExtendedProfile";
+import { NewMessage } from "./api/definitions/NewMessage";
+import { getRequiredStringEnv } from "./utils/env";
+
+// HTTP external requests timeout in milliseconds
+const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
+
+// Whether we're in a production environment
+const isProduction = process.env.NODE_ENV === "production";
+
+// Needed to call notifications API
+const adminApiUrl = getRequiredStringEnv("ADMIN_API_URL");
+const adminApiKey = getRequiredStringEnv("ADMIN_API_KEY");
+
+// TODO: decide text for welcome message
+// TODO: switch text based on user's preferred_language
+const createWelcomeMessageMarkdown = (profile: ExtendedProfile) =>
+  `Hello new user ${profile.email}
+
+  We welcome you to the digital citizenship API program  
+  This is a welcome message to test the system (if it works)`;
+
+const createWelcomeMessageSubject = (profile: ExtendedProfile) =>
+  `Welcome new user ${profile.email}`;
+
+const ContextWithBindings = t.exact(
+  t.interface({
+    bindings: t.partial({ notificationEvent: t.object })
+  })
+);
+
+type ContextWithBindings = t.TypeOf<typeof ContextWithBindings> & IContext;
+
+async function sendWelcomeMessage(
+  url: string,
+  apiKey: string,
+  newMessage: NewMessage
+): Promise<request.Response> {
+  return request("POST", url)
+    .set("Content-Type", "application/json")
+    .set("Ocp-Apim-Subscription-Key", apiKey)
+    .timeout(DEFAULT_REQUEST_TIMEOUT_MS)
+    .send(newMessage);
+}
+
+export async function index(
+  context: ContextWithBindings,
+  event: IProfileCreatedEvent | IProfileUpdatedEvent
+): Promise<Response | void> {
+  const logLevel = isProduction ? "info" : "debug";
+  configureAzureContextTransport(context, winston, logLevel);
+
+  winston.debug(
+    "ProfileEventsQueueHandler|Received event=%s",
+    JSON.stringify(event)
+  );
+
+  const url = adminApiUrl + "/api/v1/messages/" + event.fiscalCode;
+
+  const hasEnabledInbox =
+    event.newProfile.is_inbox_enabled === true &&
+    (event.kind === "ProfileCreatedEvent" ||
+      (event.kind === "ProfileUpdatedEvent" &&
+        event.oldProfile.is_inbox_enabled !==
+          event.newProfile.is_inbox_enabled));
+
+  if (hasEnabledInbox) {
+    const newMessage = NewMessage.decode({
+      content: {
+        markdown: createWelcomeMessageMarkdown(event.newProfile),
+        subject: createWelcomeMessageSubject(event.newProfile)
+      }
+    }).getOrElseL(errs => {
+      throw new Error("Invalid welcome message: " + readableReport(errs));
+    });
+
+    winston.debug(
+      `ProfileEventsQueueHandler|Sending welcome message to ${url}`
+    );
+
+    // TODO: schedule retries
+    sendWelcomeMessage(url, adminApiKey, newMessage).then(response => {
+      winston.debug(
+        `WelcomMessageEventHandler|Welcome message sent to ${
+          event.fiscalCode
+        } (response status=${response.status})`
+      );
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "helmet-csp": "^2.5.1",
     "html-to-text": "^4.0.0",
     "io-ts": "^1.1.5",
-    "italia-ts-commons": "^2.7.0",
+    "italia-ts-commons": "^2.9.0",
     "json-set-map": "^1.0.2",
     "nodemailer": "^4.6.7",
     "referrer-policy": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3688,9 +3688,9 @@ istanbul-reports@^1.3.0:
   dependencies:
     handlebars "^4.0.3"
 
-italia-ts-commons@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/italia-ts-commons/-/italia-ts-commons-2.7.0.tgz#c18484e9531fcd7a14ec52c811644971d71a5cda"
+italia-ts-commons@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/italia-ts-commons/-/italia-ts-commons-2.9.0.tgz#dfc3561129487f564cc31cfa0a52a56090d18cd7"
   dependencies:
     fp-ts "^1.6.0"
     io-ts "^1.1.4"


### PR DESCRIPTION
Reacts to messages sent to the ProfileEvents queue with one catch-all handler.

Calls the API (`submitMessageForUser`) through an HTTP request using the API-Key of the service associated to the app backend to send the welcome message.

I'd like to implement [1] using `request` method from italia-ts-commons bus in order to do that I miss the ability to add custom HTTP headers as RequestHeadersKeys are actually hardcoded.

WIP as it lacks tests.
